### PR TITLE
graphql: Fix an issue with abstract link targets.

### DIFF
--- a/tests/schemas/graphql.esdl
+++ b/tests/schemas/graphql.esdl
@@ -43,6 +43,8 @@ type User extending NamedObject {
     required property age -> int64;
     required property score -> float64;
     link profile -> Profile;
+    # a link pointing to an abstract type
+    multi link favorites -> NamedObject;
 }
 
 alias SettingAlias := Setting {
@@ -53,6 +55,12 @@ alias SettingAliasAugmented := Setting {
     of_group := .<settings[IS UserGroup] {
         name_upper := str_upper(.name)
     }
+};
+
+alias ProfileAlias := Profile {
+    # although this will point to an actual user, but the type system
+    # will only resolve an Object here
+    owner := .<profile
 };
 
 type Person extending User;

--- a/tests/schemas/graphql_setup.edgeql
+++ b/tests/schemas/graphql_setup.edgeql
@@ -61,7 +61,8 @@ INSERT User {
         name := 'Alice profile',
         value := 'special',
         tags := ['1st', '2nd'],
-    })
+    }),
+    favorites := {Setting, UserGroup}
 };
 
 INSERT Person {


### PR DESCRIPTION
Abstract link targets confused the reflection mechanism which tried to
find matching input data for possible insert mutation. Abstract link
targets cannot be directly inserted using data, but only by referring to
existing data with filters.

Aliases should not be exposed for input at all.

Fixes #990.