### PR TITLE
Fix incorrect deoptimization of references to identities in inline links

### DIFF
--- a/edb/edgeql/compiler/viewgen.py
+++ b/edb/edgeql/compiler/viewgen.py
@@ -619,8 +619,8 @@ def _normalize_view_ptr_expr(
                         ctx=ctx,
                     )
                 except errors.SchemaError as e:
-                    if shape_el.compexpr is not None:
-                        e.set_source_context(shape_el.compexpr.context)
+                    if compexpr is not None:
+                        e.set_source_context(compexpr.context)
                     else:
                         e.set_source_context(shape_el.expr.steps[-1].context)
                     raise
@@ -656,6 +656,13 @@ def _normalize_view_ptr_expr(
 
     if qlexpr is not None:
         ctx.source_map[ptrcls] = (qlexpr, ctx, path_id, path_id_namespace)
+
+    if compexpr is not None or is_polymorphic:
+        ctx.env.schema = ptrcls.set_field_value(
+            ctx.env.schema,
+            'computable',
+            True,
+        )
 
     if not is_mutation:
         if ptr_cardinality is None:

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -182,6 +182,7 @@ class BasePointerRef(ImmutableBase):
     has_properties: bool
     required: bool
     is_derived: bool
+    is_computable: bool
     # Relation cardinality in the direction specified
     # by *direction*.
     dir_cardinality: qltypes.Cardinality
@@ -251,6 +252,9 @@ class TupleIndirectionLink(s_pointers.PseudoPointer):
     def is_tuple_indirection(self) -> bool:
         return True
 
+    def get_computable(self, schema: s_schema.Schema) -> bool:
+        return False
+
 
 class TupleIndirectionPointerRef(BasePointerRef):
     pass
@@ -285,6 +289,9 @@ class TypeIntersectionLink(s_pointers.PseudoPointer):
 
     def get_cardinality(self, schema: s_schema.Schema) -> qltypes.Cardinality:
         return self._cardinality
+
+    def get_computable(self, schema: s_schema.Schema) -> bool:
+        return False
 
     def is_type_intersection(self) -> bool:
         return True

--- a/edb/ir/typeutils.py
+++ b/edb/ir/typeutils.py
@@ -493,6 +493,7 @@ def ptrref_from_ptrcls(
         base_ptr=base_ptr,
         material_ptr=material_ptr,
         is_derived=ptrcls.get_is_derived(schema),
+        is_computable=ptrcls.get_computable(schema),
         union_components=union_components,
         union_is_concrete=union_is_concrete,
         has_properties=ptrcls.has_user_defined_properties(schema),
@@ -568,4 +569,4 @@ def is_inbound_ptrref(ptrref: irast.BasePointerRef) -> bool:
 
 def is_computable_ptrref(ptrref: irast.BasePointerRef) -> bool:
     """Return True if pointer described by *ptrref* is computed."""
-    return ptrref.is_derived
+    return ptrref.is_computable

--- a/edb/schema/pointers.py
+++ b/edb/schema/pointers.py
@@ -175,6 +175,15 @@ class Pointer(referencing.ReferencedInheritingObject,
         default=False, compcoef=0.909,
         merge_fn=merge_readonly)
 
+    # For non-derived pointers this is strongly correlated with
+    # "expr" below.  Derived pointers might have "computable" set,
+    # but expr=None.
+    computable = so.SchemaField(
+        bool,
+        default=None,
+        ephemeral=True,
+    )
+
     # Computable pointers have this set to an expression
     # definining them.
     expr = so.SchemaField(
@@ -665,19 +674,9 @@ class PointerCommandOrFragment:
                     expr_rptr.ptrref, schema=schema
                 )
 
-        self.add(
-            sd.AlterObjectProperty(
-                property='expr',
-                new_value=expr,
-            )
-        )
-
-        self.add(
-            sd.AlterObjectProperty(
-                property='cardinality',
-                new_value=expr.irast.cardinality
-            )
-        )
+        self.set_attribute_value('expr', expr)
+        self.set_attribute_value('cardinality', expr.irast.cardinality)
+        self.set_attribute_value('computable', True)
 
         return target, base
 


### PR DESCRIPTION
The current implementation effectively deoptimizes all references to
identities in inlines links, if the link is from a type variant, which
is incorrect, since only type intersection paths in polymorphic queries
and actual computables need this treatment.