### PR TITLE
Add type annotations for schema name and expr modules (#1096)

### DIFF
--- a/edb/schema/name.py
+++ b/edb/schema/name.py
@@ -25,8 +25,7 @@ import functools
 from edb import errors
 
 
-if TYPE_CHECKING:
-    NameT = TypeVar("NameT", bound="SchemaName")
+NameT = TypeVar("NameT", bound="SchemaName")
 
 
 class SchemaName(str):
@@ -67,9 +66,9 @@ class SchemaName(str):
         result.name = _name
         result.module = _module
 
-        return result
+        return cast(NameT, result)
 
-    def as_tuple(self):
+    def as_tuple(self) -> Tuple[str, str]:
         return (self.module, self.name)
 
     @staticmethod
@@ -79,14 +78,14 @@ class SchemaName(str):
 
 class UnqualifiedName(SchemaName):
 
-    def __new__(cls: Type[NameT], name: str) -> NameT:
+    def __new__(cls, name: str) -> UnqualifiedName:
         # Ignore below since Mypy doesn't believe you can pass `name` to
         # object.__new__.
         result = str.__new__(cls, name)  # type: ignore
         result.name = name
         result.module = ''
 
-        return result
+        return cast(UnqualifiedName, result)
 
 
 Name = SchemaName

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -1684,7 +1684,7 @@ class TypeCommand(sd.ObjectCommand):
     @classmethod
     def _compile_view_expr(
         cls,
-        expr: qlast.Expr,
+        expr: qlast.Base,
         classname: s_name.SchemaName,
         schema: s_schema.Schema,
         context: sd.CommandContext,

--- a/mypy.ini
+++ b/mypy.ini
@@ -264,3 +264,35 @@ no_implicit_optional = True
 warn_unused_ignores = True
 warn_return_any = True
 no_implicit_reexport = True
+
+[mypy-edb.schema.name]
+follow_imports = True
+ignore_errors = False
+# Equivalent of --strict on the command line:
+disallow_subclassing_any = True
+disallow_any_generics = True
+# disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True
+
+[mypy-edb.schema.expr]
+follow_imports = True
+ignore_errors = False
+# Equivalent of --strict on the command line:
+disallow_subclassing_any = True
+disallow_any_generics = True
+# disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 42.98)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 44.43)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 11.23)


### PR DESCRIPTION
* annotations for schema name and expr

* annotations for schema name and expr

* updates schema code coverage assertion

* improves formatting for expr.get_expr_referrers function

* corrects return type annotation for get_expr_referrers

* applies corrections from comments

* removes trailing whitespace (flake8 fail)