### PR TITLE
Keep coverage results when running edb test --cov (#1104)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ docs/_build
 /.vscode
 /.pytest_cache
 /.mypy_cache
+

--- a/edb/tools/test/__init__.py
+++ b/edb/tools/test/__init__.py
@@ -23,6 +23,7 @@ import contextlib
 import functools
 import os
 import pathlib
+import shutil
 import sys
 import tempfile
 import unittest
@@ -204,6 +205,9 @@ def _coverage_wrapper(paths):
             report_cov.load()
             click.secho('Coverage:')
             report_cov.report()
+            # store the coverage file in cwd, so it can be used to produce
+            # additional reports with coverage cli
+            shutil.copy(covfile, '.')
 
 
 def _run(*, include, exclude, verbosity, files, jobs, output_format,


### PR DESCRIPTION
* closes #1101

* closes #1101 (deletes the folder with results before every run with --cov)

* cqa_flake8 fix

* corrects typo in comment

* keeps temp folder, copies only .coverage file