### PR TITLE
Use pycodestyle from git 

### DIFF
--- a/edb/common/colorsys.py
+++ b/edb/common/colorsys.py
@@ -217,7 +217,7 @@ class Color:
         return cls(r, g, b, a=alpha)
 
     @classmethod
-    def from_hls(cls, h, l, s, alpha=1.):
+    def from_hls(cls, h, l, s, alpha=1.):  # NoQA: E741
         return cls(*(int(c * 255) for c in hls_to_rgb(h, l, s)), a=alpha)
 
     def rgb_channels(self, *, as_floats=False):

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -2221,10 +2221,10 @@ class PointerMetaCommand(MetaCommand, sd.ObjectCommand,
             elif src.get_name(schema) == 'std::link':
                 return True
             else:
-                for l in src.children(schema):
-                    if not l.generic(schema):
+                for link in src.children(schema):
+                    if not link.generic(schema):
                         ptr_stor_info = types.get_pointer_storage_info(
-                            l, resolve_type=False, schema=schema)
+                            link, resolve_type=False, schema=schema)
                         if ptr_stor_info.table_type == 'link':
                             return True
                 return False
@@ -3423,17 +3423,17 @@ class UpdateEndpointDeleteActions(MetaCommand):
         for source, src_schema in affected_sources:
             links = []
 
-            for l in source.get_pointers(src_schema).objects(src_schema):
-                if (not isinstance(l, s_links.Link)
-                        or not l.get_is_local(src_schema)
-                        or l.is_pure_computable(src_schema)):
+            for link in source.get_pointers(src_schema).objects(src_schema):
+                if (not isinstance(link, s_links.Link)
+                        or not link.get_is_local(src_schema)
+                        or link.is_pure_computable(src_schema)):
                     continue
                 ptr_stor_info = types.get_pointer_storage_info(
-                    l, schema=src_schema)
+                    link, schema=src_schema)
                 if ptr_stor_info.table_type != 'link':
                     continue
 
-                links.append(l)
+                links.append(link)
 
             links.sort(
                 key=lambda l: (l.get_on_target_delete(src_schema),
@@ -3449,22 +3449,25 @@ class UpdateEndpointDeleteActions(MetaCommand):
             links = []
             inline_links = []
 
-            for l in schema.get_referrers(target, scls_type=s_links.Link,
-                                          field_name='target'):
-                if not l.get_is_local(schema) or l.is_pure_computable(schema):
+            for link in schema.get_referrers(target, scls_type=s_links.Link,
+                                             field_name='target'):
+                if (not link.get_is_local(schema)
+                        or link.is_pure_computable(schema)):
                     continue
                 ptr_stor_info = types.get_pointer_storage_info(
-                    l, schema=schema)
+                    link, schema=schema)
                 if ptr_stor_info.table_type != 'link':
-                    if l.get_on_target_delete(schema) is DA.DEFERRED_RESTRICT:
-                        deferred_inline_links.append(l)
+                    if (link.get_on_target_delete(schema)
+                            is DA.DEFERRED_RESTRICT):
+                        deferred_inline_links.append(link)
                     else:
-                        inline_links.append(l)
+                        inline_links.append(link)
                 else:
-                    if l.get_on_target_delete(schema) is DA.DEFERRED_RESTRICT:
-                        deferred_links.append(l)
+                    if (link.get_on_target_delete(schema)
+                            is DA.DEFERRED_RESTRICT):
+                        deferred_links.append(link)
                     else:
-                        links.append(l)
+                        links.append(link)
 
             links.sort(
                 key=lambda l: (l.get_on_target_delete(schema),

--- a/edb/schema/objtypes.py
+++ b/edb/schema/objtypes.py
@@ -112,25 +112,25 @@ class BaseObjectType(sources.Source,
                 'references to concrete pointers must not be qualified')
 
         ptrs = {
-            l for l in schema.get_referrers(self, scls_type=links.Link,
-                                            field_name='target')
+            lnk for lnk in schema.get_referrers(self, scls_type=links.Link,
+                                                field_name='target')
             if (
-                l.get_shortname(schema).name == name
-                and not l.get_source(schema).is_view(schema)
-                and l.get_is_local(schema)
-                and (not sources or l.get_source(schema) in sources)
+                lnk.get_shortname(schema).name == name
+                and not lnk.get_source(schema).is_view(schema)
+                and lnk.get_is_local(schema)
+                and (not sources or lnk.get_source(schema) in sources)
             )
         }
 
         for obj in self.get_ancestors(schema).objects(schema):
             ptrs.update(
-                l for l in schema.get_referrers(obj, scls_type=links.Link,
-                                                field_name='target')
+                lnk for lnk in schema.get_referrers(obj, scls_type=links.Link,
+                                                    field_name='target')
                 if (
-                    l.get_shortname(schema).name == name
-                    and not l.get_source(schema).is_view(schema)
-                    and l.get_is_local(schema)
-                    and (not sources or l.get_source(schema) in sources)
+                    lnk.get_shortname(schema).name == name
+                    and not lnk.get_source(schema).is_view(schema)
+                    and lnk.get_is_local(schema)
+                    and (not sources or lnk.get_source(schema) in sources)
                 )
             )
 

--- a/edb/schema/scalars.py
+++ b/edb/schema/scalars.py
@@ -300,7 +300,7 @@ class RebaseScalarType(ScalarTypeCommand, inheriting.RebaseInheritingObject):
             raise errors.SchemaError(
                 f'cannot remove labels from an enumeration type')
 
-        existing = [l for l in new_labels if l in cur_set]
+        existing = [label for label in new_labels if label in cur_set]
         if existing != cur_labels:
             raise errors.SchemaError(
                 f'cannot change the relative order of existing labels '

--- a/edb/tools/gen_errors.py
+++ b/edb/tools/gen_errors.py
@@ -275,7 +275,7 @@ class ErrorsTree:
 
         lines = '\n\n\n'.join(lines)
 
-        all_lines = '    ' + ',\n    '.join(repr(l) for l in all_lines) + ','
+        all_lines = '    ' + ',\n    '.join(repr(ln) for ln in all_lines) + ','
         all_lines = f'__all__ = {extra_all} + (\n{all_lines}\n)'
 
         code = (

--- a/setup.py
+++ b/setup.py
@@ -73,13 +73,17 @@ BUILD_DEPS = [
     CYTHON_DEPENDENCY,
 ]
 
+PYCODESTYLE_REPO = 'http://github.com/PyCQA/pycodestyle'
+PYCODESTYLE_COMMIT = 'd69c15eb7ecf77e94988fb55207a78936b48079c'
+
 EXTRA_DEPS = {
     'test': [
+        # Depend on unreleased version for Python 3.8 support,
+        f'pycodestyle @ {PYCODESTYLE_REPO}/archive/{PYCODESTYLE_COMMIT}.zip',
         'black~=19.3b0',
         'flake8~=3.7.9',
         'flake8-bugbear~=19.8.0',
         'mypy==0.750',
-        'pycodestyle~=2.5.0',
         'coverage~=4.5.2',
         'requests-xml~=0.2.3',
         'lxml',


### PR DESCRIPTION
We switched to Python 3.8, but can't actually use any of the new syntax,
because pycodestyle is hopelessly stuck on a year-old release.
Circumvent this by using a direct URL to a Github tarball.