### PR TITLE
Fixing broken CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,6 +58,7 @@ jobs:
     - name: Install system deps
       if: steps.buildcache.outputs.cache-hit != 'true'
       run: |
+        sudo apt-get update
         sudo apt-get install -y uuid-dev libreadline-dev bison flex
 
     - name: Build


### PR DESCRIPTION
The Gihub's debian package repo seems to be broken at the moment:

    E: Failed to fetch ... uuid-dev_2.31.1-0.4ubuntu3.4_amd64.deb
       404  Not Found [IP: 52.177.174.250 80]

This breaks the test workflow.  Thankfully, this can be fixed by
updating the repo index explicitly (which is probably a good idea
anyway).