### PR TITLE
graphql: Add an explicit error for reflecting tuples.

### DIFF
--- a/docs/clients/99_graphql/index.rst
+++ b/docs/clients/99_graphql/index.rst
@@ -36,6 +36,19 @@ Pointing your browser to ``http://127.0.0.1:8888/explore``
 will bring up a `GraphiQL`_ interface to EdgeDB. This interface can be
 used to try out queries and explore the GraphQL capabilities.
 
+
+Known Limitations
+=================
+
+- Due to the differences between EdgeQL and GraphQL syntax
+  :eql:type:`enum <std::enum>` types which have values that cannot be
+  represented as GraphQL identifiers (e.g. ``'N/A'`` or ``'NOT
+  APPLICABLE'``) cannot be properly reflected into GraphQL enums.
+
+- EdgeDB :eql:type:`tuples <std::tuple>` are not supported in GraphQL
+  reflection currently.
+
+
 .. __: http://graphql.org/docs/queries/
 
 .. _`GraphiQL`: https://github.com/graphql/graphiql

--- a/edb/graphql/types.py
+++ b/edb/graphql/types.py
@@ -299,6 +299,11 @@ class GQLCoreSchema:
             if name in self._gql_enums:
                 target = self._gql_enums.get(name)
 
+        elif edb_target.is_tuple():
+            edb_typename = edb_target.get_verbosename(self.edb_schema)
+            raise g_errors.GraphQLCoreError(
+                f"Could not convert {edb_typename} to a GraphQL type.")
+
         else:
             base_target = edb_target.get_topmost_concrete_base(self.edb_schema)
             bt_name = base_target.get_name(self.edb_schema)


### PR DESCRIPTION
Currently tuples are not supported in GraphQL. The GraphQL documentation
is also updated to reflect this fact.

Issue: #1175.