### PR TITLE
Handle tuple indirection as a regular path

### DIFF
--- a/edb/edgeql/compiler/inference/cardinality.py
+++ b/edb/edgeql/compiler/inference/cardinality.py
@@ -581,17 +581,6 @@ def __infer_tuple(
         [el.val for el in ir.elements], scope_tree, env)
 
 
-@_infer_cardinality.register
-def __infer_tuple_indirection(
-    ir: irast.TupleIndirection,
-    scope_tree: irast.ScopeTreeNode,
-    env: context.Environment,
-) -> qltypes.Cardinality:
-    # the cardinality of the tuple indirection is the same as the
-    # cardinality of the underlying tuple
-    return infer_cardinality(ir.expr, scope_tree, env)
-
-
 def infer_cardinality(
     ir: irast.Base,
     scope_tree: irast.ScopeTreeNode,

--- a/edb/edgeql/compiler/inference/types.py
+++ b/edb/edgeql/compiler/inference/types.py
@@ -487,21 +487,6 @@ def __infer_tuple(
         env.schema, element_types=element_types, named=ir.named)
 
 
-@_infer_type.register
-def __infer_tuple_indirection(
-    ir: irast.TupleIndirection,
-    env: context.Environment,
-) -> s_types.Type:
-    tuple_type = infer_type(ir.expr, env)
-    assert isinstance(tuple_type, s_types.Tuple)
-    result = tuple_type.get_subtype(env.schema, ir.name)
-    if result is None:
-        raise errors.QueryError('could not determine struct element type',
-                                context=ir.context)
-
-    return result
-
-
 def infer_type(ir: irast.Base, env: context.Environment) -> s_types.Type:
     result = env.inferred_types.get(ir)
     if result is not None:

--- a/edb/edgeql/compiler/setgen.py
+++ b/edb/edgeql/compiler/setgen.py
@@ -669,7 +669,7 @@ def tuple_indirection_set(
         path_tip: irast.Set, *,
         source: s_types.Type,
         ptr_name: str,
-        source_context: parsing.ParserContext,
+        source_context: Optional[parsing.ParserContext] = None,
         ctx: context.ContextLevel) -> irast.Set:
 
     assert isinstance(source, s_types.Tuple)
@@ -680,11 +680,19 @@ def tuple_indirection_set(
 
     path_id = pathctx.get_tuple_indirection_path_id(
         path_tip.path_id, el_norm_name, el_type, ctx=ctx)
-    expr = irast.TupleIndirection(
-        expr=path_tip, name=el_norm_name, path_id=path_id,
-        context=source_context)
 
-    return expression_set(expr, ctx=ctx)
+    ti_set = new_set(stype=el_type, path_id=path_id, ctx=ctx)
+
+    ptr = irast.TupleIndirectionPointer(
+        source=path_tip,
+        target=ti_set,
+        ptrref=path_id.rptr(),
+        direction=path_id.rptr_dir(),
+    )
+
+    ti_set.rptr = ptr
+
+    return ti_set
 
 
 def type_intersection_set(

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -793,9 +793,9 @@ def compile_query_subject(
         # `Spam.alias` should be a subclass of `Spam.bar` inheriting
         # its properties.
         base_ptrcls = typegen.ptrcls_from_ptrref(expr_rptr.ptrref, ctx=ctx)
-        assert isinstance(base_ptrcls, s_pointers.Pointer)
-        view_rptr.base_ptrcls = base_ptrcls
-        view_rptr.ptrcls_is_alias = True
+        if isinstance(base_ptrcls, s_pointers.Pointer):
+            view_rptr.base_ptrcls = base_ptrcls
+            view_rptr.ptrcls_is_alias = True
 
     if (ctx.expr_exposed
             and viewgen.has_implicit_tid(

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -357,6 +357,11 @@ class TypeIntersectionPointer(Pointer):
     ptrref: TypeIntersectionPointerRef
 
 
+class TupleIndirectionPointer(Pointer):
+
+    ptrref: TupleIndirectionPointerRef
+
+
 class Expr(Base):
     __abstract_node__ = True
 
@@ -609,13 +614,6 @@ class OperatorCall(Call):
 
     # The module id of the origin operator if this is a derivative operator.
     origin_module_id: uuid.UUID
-
-
-class TupleIndirection(ImmutableExpr):
-
-    expr: Set
-    name: str
-    path_id: PathId
 
 
 class IndexIndirection(ImmutableExpr):

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -451,19 +451,6 @@ def compile_Array(
     return relgen.build_array_expr(expr, elements, ctx=ctx)
 
 
-@dispatch.compile.register(irast.TupleIndirection)
-def compile_TupleIndirection(
-        expr: irast.TupleIndirection, *,
-        ctx: context.CompilerContextLevel) -> pgast.BaseExpr:
-    tuple_expr = expr.expr.expr
-    assert isinstance(tuple_expr, irast.Tuple)
-    for se in tuple_expr.elements:
-        if se.name == expr.name:
-            return dispatch.compile(se.val, ctx=ctx)
-
-    raise ValueError(f'no tuple element with name {expr.name}')
-
-
 @dispatch.compile.register(irast.Tuple)
 def compile_Tuple(
         expr: irast.Tuple, *,

--- a/tests/test_edgeql_linkatoms.py
+++ b/tests/test_edgeql_linkatoms.py
@@ -1021,6 +1021,25 @@ class TestEdgeQLLinkToScalarTypes(tb.QueryTestCase):
             }
         )
 
+    async def test_edgeql_links_derived_tuple_02(self):
+        await self.assert_query_result(
+            r'''
+                WITH MODULE test
+                SELECT Item {
+                    n1 := (Item.name, 'foo'),
+                }
+                FILTER
+                    .n1.0 = 'chair'
+                ORDER BY
+                    .name;
+            ''',
+            [
+                {
+                    'n1': ['chair', 'foo'],
+                },
+            ],
+        )
+
     async def test_edgeql_links_derived_array_01(self):
         await self.assert_query_result(
             r'''

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -206,7 +206,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "common" / "markup", 0)
 
     def test_cqa_type_coverage_edgeql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "edgeql", 42.46)
+        self.assertFunctionCoverage(EDB_DIR / "edgeql", 42.36)
 
     def test_cqa_type_coverage_edgeql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "edgeql" / "compiler", 100.00)
@@ -230,7 +230,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "ir", 100.00)
 
     def test_cqa_type_coverage_pgsql(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "pgsql", 46.61)
+        self.assertFunctionCoverage(EDB_DIR / "pgsql", 46.57)
 
     def test_cqa_type_coverage_pgsql_compiler(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "pgsql" / "compiler", 100.00)


### PR DESCRIPTION
Currently, tuple indirections are handled as expression paths (via the
`TupleIndirection` node), but this is redudant, since the `path_id` of
the indirection already contains all the information needed to process
such expressions.  It is also a source of bugs, as evidenced in #1255.
The solution is quite simple: drop `TupleIndirection` expression node
and treat tuple indirections as special path steps, akin to type
intersection steps.

Fixes: #1255.