### PR TITLE
Fix compiler crash on some queries with object-returning functions

### DIFF
--- a/edb/pgsql/compiler/pathctx.py
+++ b/edb/pgsql/compiler/pathctx.py
@@ -618,7 +618,7 @@ def maybe_get_path_rvar(
         return None
 
 
-def list_path_rvar_aspects(
+def list_path_aspects(
         stmt: pgast.Query, path_id: irast.PathId, *,
         env: context.Environment) -> Set[str]:
 
@@ -626,6 +626,14 @@ def list_path_rvar_aspects(
 
     for rvar_path_id, aspect in stmt.path_rvar_map:
         if path_id == rvar_path_id:
+            aspects.add(aspect)
+
+    for ns_path_id, aspect in stmt.path_namespace:
+        if path_id == ns_path_id:
+            aspects.add(aspect)
+
+    for ns_path_id, aspect in stmt.path_outputs:
+        if path_id == ns_path_id:
             aspects.add(aspect)
 
     return aspects

--- a/edb/pgsql/compiler/relgen.py
+++ b/edb/pgsql/compiler/relgen.py
@@ -1074,13 +1074,11 @@ def process_set_as_subquery(
             stmt.where_clause = astutils.extend_binop(
                 stmt.where_clause, cond_expr)
 
+    aspects = pathctx.list_path_aspects(stmt, inner_id, env=ctx.env)
     if inner_id.is_tuple_path():
         # If we are wrapping a tuple expression, make sure not to
         # over-represent it in terms of the exposed aspects.
-        aspects = pathctx.list_path_rvar_aspects(stmt, inner_id, env=ctx.env)
         aspects -= {'serialized'}
-    else:
-        aspects = {'value', 'source'}
 
     sub_rvar = relctx.new_rel_rvar(ir_set, stmt, ctx=ctx)
     return new_simple_set_rvar(ir_set, sub_rvar, aspects)

--- a/tests/test_edgeql_ddl.py
+++ b/tests/test_edgeql_ddl.py
@@ -1365,6 +1365,12 @@ class TestEdgeQLDDL(tb.DDLTestCase):
         )
         await self.assert_query_result(
             r"""
+                SELECT (SELECT test::my_edgeql_func2('schema::Object')).name;
+            """,
+            ['schema::Object'],
+        )
+        await self.assert_query_result(
+            r"""
                 SELECT test::my_edgeql_func3(1);
             """,
             [11],


### PR DESCRIPTION
Currently, queries like

    SELECT (SELECT obj_returning()).prop

are crashing the compiler because `process_set_as_subquery()` advertises
`source` aspect of the wrapped set improperly, as functions only have
the `identity` or `value` aspect.

Fixes: #1259