### PR TITLE
Implement `JSON_ELEMENTS` IO format for responses (#1169)

### DIFF
--- a/docs/internals/protocol/messages.rst
+++ b/docs/internals/protocol/messages.rst
@@ -303,8 +303,17 @@ Format:
     };
 
     enum IOFormat {
+        // Default format that should be used in most cases
         BINARY = 0x62,
-        JSON = 0x6a
+
+        // Returns a single row and single field that contains
+        // a resultset as a single JSON array
+        JSON = 0x6a,
+
+        // Returns a single JSON string per top-level set element.
+        // Preferred over JSON format because might be used for
+        // larger responses
+        JSON_ELEMENTS = 0x4a,
     };
 
     enum Cardinality {

--- a/edb/pgsql/compiler/context.py
+++ b/edb/pgsql/compiler/context.py
@@ -52,6 +52,7 @@ class OutputFormat(enum.Enum):
     NATIVE = enum.auto()
     JSON = enum.auto()
     JSONB = enum.auto()
+    JSON_ELEMENTS = enum.auto()
 
 
 class NoVolatilitySentinel:

--- a/edb/pgsql/compiler/output.py
+++ b/edb/pgsql/compiler/output.py
@@ -32,9 +32,12 @@ from edb.pgsql import types as pgtypes
 from . import context
 
 
+_JSON_FORMATS = {context.OutputFormat.JSON, context.OutputFormat.JSON_ELEMENTS}
+
+
 def _get_json_func(name: str, *,
                    env: context.Environment) -> Tuple[str, ...]:
-    if env.output_format is context.OutputFormat.JSON:
+    if env.output_format in _JSON_FORMATS:
         prefix_suffix = 'json'
     else:
         prefix_suffix = 'jsonb'
@@ -428,6 +431,7 @@ def serialize_expr(
         env: context.Environment) -> pgast.BaseExpr:
 
     if env.output_format in (context.OutputFormat.JSON,
+                             context.OutputFormat.JSON_ELEMENTS,
                              context.OutputFormat.JSONB):
         val = serialize_expr_to_json(
             expr, path_id=path_id, nested=nested, env=env)
@@ -448,7 +452,7 @@ def get_pg_type(
     if in_serialization_ctx(ctx):
         if ctx.env.output_format is context.OutputFormat.JSONB:
             return ('jsonb',)
-        elif ctx.env.output_format is context.OutputFormat.JSON:
+        elif ctx.env.output_format in _JSON_FORMATS:
             return ('json',)
         elif irtyputils.is_object(typeref):
             return ('record',)
@@ -541,4 +545,5 @@ def top_output_as_value(
         return stmt
 
     else:
+        # JSON_ELEMENTS and BINARY don't require any wrapping
         return stmt

--- a/edb/server/compiler/__init__.py
+++ b/edb/server/compiler/__init__.py
@@ -24,12 +24,13 @@ from .compiler import compile_edgeql_script, compile_bootstrap_script
 from .compiler import load_std_schema
 from .dbstate import QueryUnit
 from .enums import Capability, CompileStatementMode, ResultCardinality
+from .enums import IoFormat
 
 
 __all__ = (
     'Compiler', 'BaseCompiler', 'CompilerDatabaseState',
     'QueryUnit',
-    'Capability', 'CompileStatementMode', 'ResultCardinality',
+    'Capability', 'CompileStatementMode', 'ResultCardinality', 'IoFormat',
     'compile_edgeql_script',
     'compile_bootstrap_script',
     'load_std_schema',

--- a/edb/server/compiler/enums.py
+++ b/edb/server/compiler/enums.py
@@ -54,3 +54,9 @@ class Capability(enum.Flag):
     QUERY = enum.auto()
 
     ALL = DDL | TRANSACTION | SESSION | QUERY
+
+
+class IoFormat(strenum.StrEnum):
+    BINARY = 'BINARY'
+    JSON = 'JSON'
+    JSON_ELEMENTS = 'JSON_ELEMENTS'

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -73,10 +73,10 @@ cdef class DatabaseConnectionView:
     cdef in_tx(self)
     cdef in_tx_error(self)
 
-    cdef cache_compiled_query(self, bytes eql, bint json_mode,
+    cdef cache_compiled_query(self, bytes eql, object io_format,
                               bint expect_one, int implicit_limit,
                               query_unit)
-    cdef lookup_compiled_query(self, bytes eql, bint json_mode,
+    cdef lookup_compiled_query(self, bytes eql, object io_format,
                                bint expect_one, int implicit_limit)
 
     cdef tx_error(self)

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -168,12 +168,12 @@ cdef class DatabaseConnectionView:
     cdef in_tx_error(self):
         return self._tx_error
 
-    cdef cache_compiled_query(self, bytes eql, bint json_mode, bint expect_one,
-                              int implicit_limit, query_unit):
+    cdef cache_compiled_query(self, bytes eql, object io_format,
+                              bint expect_one, int implicit_limit, query_unit):
 
         assert query_unit.cacheable
 
-        key = (eql, json_mode, expect_one, implicit_limit,
+        key = (eql, io_format, expect_one, implicit_limit,
                self._modaliases, self._config)
 
         if self._in_tx_with_ddl:
@@ -181,14 +181,14 @@ cdef class DatabaseConnectionView:
         else:
             self._db._cache_compiled_query(key, query_unit)
 
-    cdef lookup_compiled_query(self, bytes eql, bint json_mode,
+    cdef lookup_compiled_query(self, bytes eql, object io_format,
                                bint expect_one, int implicit_limit):
         if (self._tx_error or
                 not self._query_cache_enabled or
                 self._in_tx_with_ddl):
             return None
 
-        key = (eql, json_mode, expect_one, implicit_limit,
+        key = (eql, io_format, expect_one, implicit_limit,
                self._modaliases, self._config)
 
         if self._in_tx_with_ddl or self._in_tx_with_set:

--- a/edb/server/http_edgeql_port/protocol.pyx
+++ b/edb/server/http_edgeql_port/protocol.pyx
@@ -29,6 +29,7 @@ from edb.common import debug
 from edb.common import markup
 
 from edb.server import compiler
+from edb.server.compiler import IoFormat
 from edb.server.http import http
 from edb.server.http cimport http
 
@@ -131,14 +132,14 @@ cdef class Protocol(http.HttpProtocol):
                 'compile_eql',
                 dbver,
                 query,
-                None,  # modaliases
-                None,  # session config
-                True,  # json mode
-                False, # expected cardinality is MANY
-                0,     # no implicit limit
+                None,           # modaliases
+                None,           # session config
+                IoFormat.JSON,  # json mode
+                False,          # expected cardinality is MANY
+                0,              # no implicit limit
                 compiler.CompileStatementMode.SINGLE,
                 compiler.Capability.QUERY,
-                True,  # json parameters
+                True,           # json parameters
             )
             return units[0]
         finally:

--- a/edb/server/mng_port/edgecon.pxd
+++ b/edb/server/mng_port/edgecon.pxd
@@ -87,10 +87,10 @@ cdef class EdgeConnection:
 
         tuple protocol_version
         tuple max_protocol
-
+        
         object __weakref__
 
-    cdef parse_json_mode(self, bytes mode)
+    cdef _parse_io_format(self, bytes mode)
     cdef parse_cardinality(self, bytes card)
     cdef char render_cardinality(self, query_unit) except -1
 

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -2631,3 +2631,9 @@ class TestServerProtoDDL(tb.NonIsolatedDDLTestCase):
                 'SELECT {1, 2, 3}',
                 __limit__=-2,
             )
+
+    async def test_fetch_elements(self):
+        result = await self.con._fetchall_json_elements('''
+            SELECT {"test1", "test2"}
+        ''')
+        self.assertEqual(result, ['"test1"', '"test2"'])

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -248,13 +248,13 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "schema", 69.43)
 
     def test_cqa_type_coverage_server(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "server", 14.05)
+        self.assertFunctionCoverage(EDB_DIR / "server", 14.23)
 
     def test_cqa_type_coverage_server_cache(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server" / "cache", 0)
 
     def test_cqa_type_coverage_server_compiler(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "server" / "compiler", 22.86)
+        self.assertFunctionCoverage(EDB_DIR / "server" / "compiler", 23.58)
 
     def test_cqa_type_coverage_server_config(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server" / "config", 25.00)


### PR DESCRIPTION
This is important for the non-interactive REPL mode, to allow fetching
large batches of the data without keeping everything in memory (and also
without replicating the whole JSONizing process on top of a binary
protocol).

Co-authored-by: Yury Selivanov <yury@edgedb.com>