### PR TITLE
Fixes on documentation (#1266)

### DIFF
--- a/docs/internals/protocol/messages.rst
+++ b/docs/internals/protocol/messages.rst
@@ -510,7 +510,7 @@ Format:
         Headers             headers;
 
         // Data I/O format.
-        byte<IOFormat>      io_format;
+        int8<IOFormat>      io_format;
 
         // Expected result cardinality
         byte<Cardinality>   expected_cardinality;

--- a/docs/internals/protocol/overview.rst
+++ b/docs/internals/protocol/overview.rst
@@ -34,6 +34,9 @@ The following data types are used in the descriptions:
       - 64-bit integer, most significant byte first
     * - ``byte``
       - 8-bit unsigned integer
+    * - ``byte<T>``
+      - 8-bit unsigned integer enumeration, where *T* denotes the name of
+        the enumeration
     * - ``string``
       - a UTF-8 encoded text string prefixed with its byte length as ``int32``
     * - ``bytes``


### PR DESCRIPTION
- Added byte<T> definition at overview
- Changed byte<T> to int8<T> for io_format at Optimistic Execute structure