### PR TITLE
Add annotations for schema scalars (#1274)

### DIFF
--- a/edb/schema/inheriting.py
+++ b/edb/schema/inheriting.py
@@ -706,7 +706,7 @@ class AlterInheritingObject(InheritingObjectCommand,
         schema: s_schema.Schema,
         astnode: qlast.DDLOperation,
         context: sd.CommandContext,
-    ) -> AlterInheritingObject:
+    ) -> sd.Command:
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
         assert isinstance(cmd, AlterInheritingObject)
         assert isinstance(astnode, qlast.ObjectDDL)

--- a/mypy.ini
+++ b/mypy.ini
@@ -460,3 +460,19 @@ no_implicit_optional = True
 warn_unused_ignores = True
 warn_return_any = True
 no_implicit_reexport = True
+
+[mypy-edb.schema.scalars]
+follow_imports = True
+ignore_errors = False
+# Equivalent of --strict on the command line:
+disallow_subclassing_any = True
+disallow_any_generics = True
+# disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 71.99)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 73.71)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 14.23)


### PR DESCRIPTION
* first annotations on scalars

* down to two errors

* one error missing

* adds type ignore for ScalarTypeCommand._cmd_tree_from_ast

* corrects _cmd_tree_from_ast return annotation