### PR TITLE
Add annotations for schema roles, operators, casts, and modules (#1278)

### DIFF
--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -703,7 +703,7 @@ class CallableCommand(sd.QualifiedObjectCommand):
         schema: s_schema.Schema,
         context,
         cmd
-    ) -> List[ParameterDesc]:
+    ) -> Tuple[s_schema.Schema, List[ParameterDesc]]:
         params = []
         for subcmd in cmd.get_subcommands(type=CreateParameter):
             schema, param = ParameterDesc.from_create_delta(
@@ -716,7 +716,12 @@ class CallableCommand(sd.QualifiedObjectCommand):
 class CreateCallableObject(CallableCommand, sd.CreateObject):
 
     @classmethod
-    def _cmd_tree_from_ast(cls, schema: s_schema.Schema, astnode, context):
+    def _cmd_tree_from_ast(
+        cls,
+        schema: s_schema.Schema,
+        astnode: qlast.DDLOperation,
+        context: sd.CommandContext,
+    ) -> sd.Command:
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
 
         params = cls._get_param_desc_from_ast(

--- a/edb/schema/modules.py
+++ b/edb/schema/modules.py
@@ -34,22 +34,22 @@ class Module(s_anno.AnnotationSubject,
         bool, default=False, compcoef=0.4, introspectable=True)
 
 
-class ModuleCommandContext(sd.ObjectCommandContext):
+class ModuleCommandContext(sd.ObjectCommandContext[Module]):
     pass
 
 
-class ModuleCommand(sd.ObjectCommand, schema_metaclass=Module,
+class ModuleCommand(sd.ObjectCommand[Module], schema_metaclass=Module,
                     context_class=ModuleCommandContext):
     pass
 
 
-class CreateModule(ModuleCommand, sd.CreateObject):
+class CreateModule(ModuleCommand, sd.CreateObject[Module]):
     astnode = qlast.CreateModule
 
 
-class AlterModule(ModuleCommand, sd.AlterObject):
+class AlterModule(ModuleCommand, sd.AlterObject[Module]):
     astnode = qlast.AlterModule
 
 
-class DeleteModule(ModuleCommand, sd.DeleteObject):
+class DeleteModule(ModuleCommand, sd.DeleteObject[Module]):
     astnode = qlast.DropModule

--- a/mypy.ini
+++ b/mypy.ini
@@ -476,3 +476,67 @@ no_implicit_optional = True
 warn_unused_ignores = True
 warn_return_any = True
 no_implicit_reexport = True
+
+[mypy-edb.schema.roles]
+follow_imports = True
+ignore_errors = False
+# Equivalent of --strict on the command line:
+disallow_subclassing_any = True
+disallow_any_generics = True
+# disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True
+
+[mypy-edb.schema.operators]
+follow_imports = True
+ignore_errors = False
+# Equivalent of --strict on the command line:
+disallow_subclassing_any = True
+disallow_any_generics = True
+# disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True
+
+[mypy-edb.schema.casts]
+follow_imports = True
+ignore_errors = False
+# Equivalent of --strict on the command line:
+disallow_subclassing_any = True
+disallow_any_generics = True
+# disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True
+
+[mypy-edb.schema.modules]
+follow_imports = True
+ignore_errors = False
+# Equivalent of --strict on the command line:
+disallow_subclassing_any = True
+disallow_any_generics = True
+# disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 73.97)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 76.28)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 14.23)


### PR DESCRIPTION
* annotates roles.py

* starts annotations on operators

* corrects bug in operators.py

* updates schema type coverage assertion

* annotates casts.py

* annotates modules

* ignores errors on roles.Role class

* removes type ignore, corrects coverage percentage