### PR TITLE
Add annotations for schema functions (#1310)

### DIFF
--- a/edb/edgeql/compiler/__init__.py
+++ b/edb/edgeql/compiler/__init__.py
@@ -603,7 +603,7 @@ def get_param_anchors_for_callable(
 
     pg_params = s_func.PgParams.from_params(schema, params)
     for pi, p in enumerate(pg_params.params):
-        p_shortname = p.get_shortname(schema)
+        p_shortname = p.get_parameter_name(schema)
         anchors[p_shortname] = irast.Parameter(
             name=p_shortname,
             typeref=irtyputils.type_to_typeref(schema, p.get_type(schema)))

--- a/edb/edgeql/compiler/func.py
+++ b/edb/edgeql/compiler/func.py
@@ -624,7 +624,7 @@ def finalize_args(
 
         if param_mod is not ft.TypeModifier.SET_OF:
             arg_scope = pathctx.get_set_scope(arg, ctx=ctx)
-            param_shortname = param.get_shortname(ctx.env.schema)
+            param_shortname = param.get_parameter_name(ctx.env.schema)
 
             # Arg was wrapped for scope fencing purposes,
             # but that fence has been removed above, so unwrap it.

--- a/edb/edgeql/compiler/polyres.py
+++ b/edb/edgeql/compiler/polyres.py
@@ -264,7 +264,7 @@ def try_bind_call_args(
 
         pi += 1
 
-        param_shortname = param.get_shortname(schema)
+        param_shortname = param.get_parameter_name(schema)
         param_type = param.get_type(schema)
         if param_shortname in kwargs:
             matched_kwargs += 1
@@ -376,7 +376,7 @@ def try_bind_call_args(
                         f'failed to resolve the parameter for the arg #{i}')
 
                 param = barg.param
-                param_shortname = param.get_shortname(schema)
+                param_shortname = param.get_parameter_name(schema)
                 null_args.add(param_shortname)
 
                 defaults_mask |= 1 << i

--- a/edb/edgeql/utils.py
+++ b/edb/edgeql/utils.py
@@ -82,12 +82,14 @@ def index_parameters(
         if variadic and variadic_num == i:
             assert varargs is None
             varargs = []
-            result[p.get_shortname(schema)] = qlast.Array(elements=varargs)
+            result[p.get_parameter_name(schema)] = qlast.Array(
+                elements=varargs
+            )
 
         if varargs is not None:
             varargs.append(e)
         else:
-            result[p.get_shortname(schema)] = e
+            result[p.get_parameter_name(schema)] = e
 
     return result
 

--- a/edb/pgsql/delta.py
+++ b/edb/pgsql/delta.py
@@ -581,7 +581,7 @@ class FunctionCommand:
             if compile_defaults and param_default is not None:
                 default = self.compile_default(func, param_default, schema)
 
-            args.append((param.get_shortname(schema), pg_at, default))
+            args.append((param.get_parameter_name(schema), pg_at, default))
 
         return args
 
@@ -733,7 +733,7 @@ class OperatorCommand(FunctionCommand):
 
         for param in pg_params.params:
             pg_at = self.get_pgtype(oper, param.get_type(schema), schema)
-            args.append((param.get_shortname(schema), pg_at))
+            args.append((param.get_parameter_name(schema), pg_at))
 
         return args
 

--- a/edb/schema/constraints.py
+++ b/edb/schema/constraints.py
@@ -500,9 +500,14 @@ class ConstraintCommand(
             params = self._get_params(schema, context)
 
             anchors: Dict[str, Any] = {}
+            # type ignore below, because so.ObjectList[Parameter]
+            # is in practice s_func.ParameterLikeList
             param_anchors, _ = (
                 qlcompiler.get_param_anchors_for_callable(
-                    params, schema, inlined_defaults=False)
+                    params,  # type: ignore
+                    schema,
+                    inlined_defaults=False
+                )
             )
             anchors.update(param_anchors)
             referrer_ctx = self.get_referrer_context(context)
@@ -511,12 +516,14 @@ class ConstraintCommand(
                 assert isinstance(referrer_ctx.op, sd.ObjectCommand)
                 anchors['__subject__'] = referrer_ctx.op.scls
 
+            # type ignore below, because so.ObjectList[Parameter]
+            # is in practice s_func.ParameterLikeList
             return s_expr.Expression.compiled(
                 value,
                 schema=schema,
                 modaliases=context.modaliases,
                 anchors=anchors,
-                func_params=params,
+                func_params=params,  # type: ignore
                 allow_generic_type_output=True,
                 parent_object_type=self.get_schema_metaclass(),
             )

--- a/edb/schema/functions.py
+++ b/edb/schema/functions.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 
 def param_as_str(
     schema: s_schema.Schema,
-    param: Union[ParameterDesc, Parameter]
+    param: Union[ParameterDesc, Parameter],
 ) -> str:
     ret = []
     kind = param.get_kind(schema)
@@ -57,7 +57,7 @@ def param_as_str(
         ret.append(kind.to_edgeql())
         ret.append(' ')
 
-    ret.append(f'{param.get_shortname(schema)}: ')
+    ret.append(f'{param.get_parameter_name(schema)}: ')
 
     if typemod is not ft.TypeModifier.SINGLETON:
         ret.append(typemod.to_edgeql())
@@ -79,7 +79,7 @@ def param_as_str(
 
 class ParameterLike(s_abc.Parameter):
 
-    def get_shortname(self, schema: s_schema.Schema) -> str:
+    def get_parameter_name(self, schema: s_schema.Schema) -> str:
         raise NotImplementedError
 
     def get_name(self, schema: s_schema.Schema) -> str:
@@ -132,9 +132,9 @@ class ParameterDesc(ParameterLike):
     def from_ast(
         cls,
         schema: s_schema.Schema,
-        modaliases,
+        modaliases: Mapping[Optional[str], str],
         num: int,
-        astnode
+        astnode: qlast.FuncParam,
     ) -> ParameterDesc:
 
         paramd = None
@@ -154,6 +154,7 @@ class ParameterDesc(ParameterLike):
                 subtypes=[paramt_ast],
             )
 
+        assert isinstance(paramt_ast, qlast.TypeName)
         paramt = utils.ast_to_type_shell(
             paramt_ast,
             modaliases=modaliases,
@@ -169,7 +170,7 @@ class ParameterDesc(ParameterLike):
             default=paramd
         )
 
-    def get_shortname(self, schema: s_schema.Schema) -> str:
+    def get_parameter_name(self, schema: s_schema.Schema) -> str:
         return self.name
 
     def get_name(self, schema: s_schema.Schema) -> str:
@@ -194,7 +195,12 @@ class ParameterDesc(ParameterLike):
         return param_as_str(schema, self)
 
     @classmethod
-    def from_create_delta(cls, schema: s_schema.Schema, context, cmd):
+    def from_create_delta(
+        cls,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        cmd: CreateParameter,
+    ) -> Tuple[s_schema.Schema, ParameterDesc]:
         props = cmd.get_attributes(schema, context)
         props['name'] = Parameter.paramname_from_fullname(props['name'])
         if not isinstance(props['type'], s_types.TypeShell):
@@ -213,10 +219,10 @@ class ParameterDesc(ParameterLike):
     def as_create_delta(
         self,
         schema: s_schema.Schema,
-        func_fqname,
+        func_fqname: sn.Name,
         *,
-        context
-    ):
+        context: sd.CommandContext,
+    ) -> sd.Command:
         CreateParameter = sd.ObjectCommandMeta.get_command_class_or_die(
             sd.CreateObject, Parameter)
 
@@ -242,10 +248,10 @@ class ParameterDesc(ParameterLike):
     def as_delete_delta(
         self,
         schema: s_schema.Schema,
-        func_fqname,
+        func_fqname: sn.Name,
         *,
-        context
-    ):
+        context: sd.CommandContext,
+    ) -> sd.Command:
         DeleteParameter = sd.ObjectCommandMeta.get_command_class_or_die(
             sd.DeleteObject, Parameter)
 
@@ -258,7 +264,7 @@ class ParameterDesc(ParameterLike):
         cmd = DeleteParameter(classname=param_name)
 
         if isinstance(self.type, s_types.CollectionTypeShell):
-            param = schema.get(param_name)
+            param = schema.get(param_name, type=Parameter)
             s_types.cleanup_schema_collection(
                 schema,
                 self.type.resolve(schema),
@@ -290,7 +296,7 @@ class Parameter(so.ObjectFragment, ParameterLike):
         ft.ParameterKind, coerce=True, compcoef=0.4)
 
     @classmethod
-    def paramname_from_fullname(cls, fullname: str) -> str:
+    def paramname_from_fullname(cls, fullname: sn.Name) -> str:
         parts = str(fullname.name).split('@@', 1)
         if len(parts) == 2:
             return sn.unmangle_name(parts[0])
@@ -303,7 +309,7 @@ class Parameter(so.ObjectFragment, ParameterLike):
         self,
         schema: s_schema.Schema,
         *,
-        with_parent: bool=False
+        with_parent: bool = False,
     ) -> str:
         vn = super().get_verbosename(schema)
         if with_parent:
@@ -317,20 +323,34 @@ class Parameter(so.ObjectFragment, ParameterLike):
         else:
             return vn
 
-    def get_shortname(self, schema: s_schema.Schema) -> str:
+    def get_shortname(self, schema: s_schema.Schema) -> sn.Name:
+        return sn.Name(
+            module=self.get_name(schema).module,
+            name=self.get_parameter_name(schema),
+        )
+
+    def get_displayname(self, schema: s_schema.Schema) -> str:
+        return self.get_parameter_name(schema)
+
+    def get_parameter_name(self, schema: s_schema.Schema) -> str:
         fullname = self.get_name(schema)
         return self.paramname_from_fullname(fullname)
 
     def get_ql_default(self, schema: s_schema.Schema) -> qlast.Base:
-        return self.get_default(schema).qlast
+        ql_default = self.get_default(schema)
+        assert ql_default is not None
+        return ql_default.qlast
 
     def get_ir_default(self, *, schema: s_schema.Schema) -> irast.Base:
+        from edb.ir import ast as irast
         from edb.ir import utils as irutils
 
         defexpr = self.get_default(schema)
+        assert defexpr is not None
         defexpr = expr.Expression.compiled(
             defexpr, as_fragment=True, schema=schema)
         ir = defexpr.irast
+        assert isinstance(ir, (Function, irast.Statement))
         if not irutils.is_const(ir.expr):
             raise ValueError('expression not constant')
         return ir
@@ -339,27 +359,37 @@ class Parameter(so.ObjectFragment, ParameterLike):
         return param_as_str(schema, self)
 
 
-class CallableCommandContext(sd.ObjectCommandContext,
+class CallableCommandContext(sd.ObjectCommandContext['CallableObject'],
                              s_anno.AnnotationSubjectCommandContext):
     pass
 
 
-class ParameterCommandContext(sd.ObjectCommandContext):
+class ParameterCommandContext(sd.ObjectCommandContext[Parameter]):
     pass
 
 
-class ParameterCommand(referencing.StronglyReferencedObjectCommand,
-                       schema_metaclass=Parameter,
-                       context_class=ParameterCommandContext,
-                       referrer_context_class=CallableCommandContext):
+# type ignore below, because making Parameter
+# a referencing.ReferencedObject breaks the code
+class ParameterCommand(
+    referencing.StronglyReferencedObjectCommand[Parameter],  # type: ignore
+    schema_metaclass=Parameter,
+    context_class=ParameterCommandContext,
+    referrer_context_class=CallableCommandContext
+):
     pass
 
 
-class CreateParameter(ParameterCommand, sd.CreateObject,
+class CreateParameter(ParameterCommand,
+                      sd.CreateObject[Parameter],
                       sd.CreateObjectFragment):
 
     @classmethod
-    def _cmd_tree_from_ast(cls, schema: s_schema.Schema, astnode, context):
+    def _cmd_tree_from_ast(
+        cls,
+        schema: s_schema.Schema,
+        astnode: qlast.DDLOperation,
+        context: sd.CommandContext,
+    ) -> sd.Command:
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
 
         for sub in cmd.get_subcommands(type=sd.AlterObjectProperty):
@@ -368,16 +398,8 @@ class CreateParameter(ParameterCommand, sd.CreateObject,
 
         return cmd
 
-    def _apply_field_ast(self, schema: s_schema.Schema, context, node, op):
-        if op.property == 'default':
-            if op.new_value:
-                op.new_value = op.new_value[0]
-                super()._apply_field_ast(schema, context, node, op)
-        else:
-            super()._apply_field_ast(schema, context, node, op)
 
-
-class DeleteParameter(ParameterCommand, sd.DeleteObject):
+class DeleteParameter(ParameterCommand, sd.DeleteObject[Parameter]):
     pass
 
 
@@ -387,7 +409,11 @@ class PgParams(NamedTuple):
     has_param_wo_default: bool
 
     @classmethod
-    def from_params(cls, schema: s_schema.Schema, params) -> PgParams:
+    def from_params(
+        cls,
+        schema: s_schema.Schema,
+        params: Union[Sequence[ParameterLike], ParameterLikeList],
+    ) -> PgParams:
         pg_params = []
         named = []
         variadic = None
@@ -420,14 +446,18 @@ class PgParams(NamedTuple):
             pg_params = named
 
         return cls(
-            params=tuple(pg_params),
+            params=tuple(cast(List[Parameter], pg_params)),
             has_param_wo_default=has_param_wo_default)
 
 
 class ParameterLikeList(abc.ABC):
 
     @abc.abstractmethod
-    def get_by_name(self, schema: s_schema.Schema, name) -> ParameterLike:
+    def get_by_name(
+        self,
+        schema: s_schema.Schema,
+        name: str,
+    ) -> Optional[ParameterLike]:
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -441,7 +471,7 @@ class ParameterLikeList(abc.ABC):
     @abc.abstractmethod
     def find_named_only(
         self,
-        schema: s_schema.Schema
+        schema: s_schema.Schema,
     ) -> Mapping[str, ParameterLike]:
         raise NotImplementedError
 
@@ -462,10 +492,15 @@ class ParameterLikeList(abc.ABC):
 
 class FuncParameterList(so.ObjectList[Parameter], ParameterLikeList):
 
-    def get_by_name(self, schema: s_schema.Schema, name) -> Parameter:
+    def get_by_name(
+        self,
+        schema: s_schema.Schema,
+        name: str,
+    ) -> Optional[Parameter]:
         for param in self.objects(schema):
-            if param.get_shortname(schema) == name:
+            if param.get_parameter_name(schema) == name:
                 return param
+        return None
 
     def as_str(self, schema: s_schema.Schema) -> str:
         ret = []
@@ -479,12 +514,12 @@ class FuncParameterList(so.ObjectList[Parameter], ParameterLikeList):
 
     def find_named_only(
         self,
-        schema: s_schema.Schema
+        schema: s_schema.Schema,
     ) -> Mapping[str, Parameter]:
         named = {}
         for param in self.objects(schema):
             if param.get_kind(schema) is ft.ParameterKind.NAMED_ONLY:
-                named[param.get_shortname(schema)] = param
+                named[param.get_parameter_name(schema)] = param
 
         return types.MappingProxyType(named)
 
@@ -492,47 +527,7 @@ class FuncParameterList(so.ObjectList[Parameter], ParameterLikeList):
         for param in self.objects(schema):
             if param.get_kind(schema) is ft.ParameterKind.VARIADIC:
                 return param
-
-    @classmethod
-    def from_ast(
-        cls,
-        schema: s_schema.Schema,
-        astnode,
-        modaliases,
-        *,
-        func_fqname,
-        prepend: Optional[List[qlast.FuncParam]]=None
-    ):
-        if not getattr(astnode, 'params', None):
-            return cls.create(schema, [])
-
-        if prepend is None:
-            prepend = []
-
-        params = []
-
-        for num, param in enumerate(prepend + list(astnode.params)):
-            param_desc = ParameterDesc.from_ast(
-                schema, modaliases, num, param)
-
-            param_name = sn.Name(
-                module=func_fqname.module,
-                name=sn.get_specialized_name(
-                    param.name, func_fqname)
-            )
-
-            schema, param = Parameter.create_in_schema(
-                schema,
-                num=num,
-                name=param_name,
-                type=param_desc.type,
-                typemod=param_desc.typemod,
-                kind=param_desc.kind,
-                default=param_desc.default)
-
-            params.append(param)
-
-        return schema, cls.create(schema, params)
+        return None
 
 
 class VolatilitySubject(so.Object):
@@ -595,10 +590,16 @@ class CallableObject(
         new_schema: s_schema.Schema,
     ) -> sd.ObjectCommand[so.Object]:
 
-        def param_is_inherited(schema: s_schema.Schema, func, param):
+        def param_is_inherited(
+            schema: s_schema.Schema,
+            func: CallableObject,
+            param: ParameterLike
+        ) -> bool:
             qualname = sn.get_specialized_name(
-                param.get_shortname(schema), func.get_name(schema))
-            return qualname != param.get_name(schema).name
+                param.get_parameter_name(schema), func.get_name(schema))
+            param_name = param.get_name(schema)
+            assert isinstance(param_name, sn.Name)
+            return qualname != param_name.name
 
         delta = super().delta(
             old,
@@ -609,6 +610,8 @@ class CallableObject(
         )
 
         if old:
+            assert isinstance(old, CallableObject)
+            assert old_schema is not None
             old_params = old.get_params(old_schema).objects(old_schema)
             oldcoll = [
                 p for p in old_params
@@ -618,6 +621,7 @@ class CallableObject(
             oldcoll = []
 
         if new:
+            assert isinstance(new, CallableObject)
             new_params = new.get_params(new_schema).objects(new_schema)
             newcoll = [
                 p for p in new_params
@@ -646,8 +650,9 @@ class CallableObject(
     ) -> Tuple[str, ...]:
         pgp = PgParams.from_params(schema, params)
 
-        quals = []
+        quals: List[str] = []
         for param in pgp.params:
+            assert isinstance(param, ParameterDesc)
             pt = param.get_type_shell(schema)
             if isinstance(pt, s_types.CollectionTypeShell):
                 quals.append(pt.get_schema_class_displayname())
@@ -692,29 +697,25 @@ class CallableObject(
         return not isinstance(reference, Parameter)
 
 
-class CallableCommand(sd.QualifiedObjectCommand):
+class CallableCommand(sd.QualifiedObjectCommand[CallableObject]):
 
-    def _get_params(self, schema: s_schema.Schema, context):
+    def _get_params(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> so.ObjectList[Parameter]:
         params = []
         for cr_param in self.get_subcommands(type=ParameterCommand):
-            param = schema.get(cr_param.classname)
+            param = schema.get(cr_param.classname, type=Parameter)
             params.append(param)
         return FuncParameterList.create(schema, params)
-
-    def _alter_innards(self, schema: s_schema.Schema, context):
-        schema = super()._alter_innards(schema, context)
-
-        for op in self.get_subcommands(metaclass=Parameter):
-            schema = op.apply(schema, context=context)
-
-        return schema
 
     @classmethod
     def _get_param_desc_from_ast(
         cls,
         schema: s_schema.Schema,
-        modaliases,
-        astnode,
+        modaliases: Mapping[Optional[str], str],
+        astnode: qlast.ObjectDDL,
         *,
         param_offset: int=0,
     ) -> List[ParameterDesc]:
@@ -723,6 +724,7 @@ class CallableCommand(sd.QualifiedObjectCommand):
             # Some Callables, like the concrete constraints,
             # have no params in their AST.
             return []
+        assert isinstance(astnode, qlast.CallableObject)
 
         for num, param in enumerate(astnode.params, param_offset):
             param_desc = ParameterDesc.from_ast(
@@ -735,8 +737,8 @@ class CallableCommand(sd.QualifiedObjectCommand):
     def _get_param_desc_from_delta(
         cls,
         schema: s_schema.Schema,
-        context,
-        cmd
+        context: sd.CommandContext,
+        cmd: sd.Command,
     ) -> Tuple[s_schema.Schema, List[ParameterDesc]]:
         params = []
         for subcmd in cmd.get_subcommands(type=CreateParameter):
@@ -747,7 +749,23 @@ class CallableCommand(sd.QualifiedObjectCommand):
         return schema, params
 
 
-class CreateCallableObject(CallableCommand, sd.CreateObject):
+class AlterCallableObject(CallableCommand,
+                          sd.AlterObject[CallableObject]):
+
+    def _alter_innards(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
+        schema = super()._alter_innards(schema, context)
+
+        for op in self.get_subcommands(metaclass=Parameter):
+            schema = op.apply(schema, context=context)
+
+        return schema
+
+
+class CreateCallableObject(CallableCommand, sd.CreateObject[CallableObject]):
 
     @classmethod
     def _cmd_tree_from_ast(
@@ -757,15 +775,21 @@ class CreateCallableObject(CallableCommand, sd.CreateObject):
         context: sd.CommandContext,
     ) -> sd.Command:
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
+        assert isinstance(astnode, qlast.CreateObject)
 
         params = cls._get_param_desc_from_ast(
             schema, context.modaliases, astnode)
 
         for param in params:
+            # as_create_delta requires the specific type
+            assert isinstance(cmd.classname, sn.SchemaName)
             cmd.add(param.as_create_delta(
                 schema, cmd.classname, context=context))
 
         if hasattr(astnode, 'returning'):
+            assert isinstance(astnode, (qlast.CreateOperator,
+                                        qlast.CreateFunction))
+            assert isinstance(astnode.returning, qlast.TypeName)
             modaliases = context.modaliases
 
             return_type = utils.ast_to_type_shell(
@@ -788,7 +812,11 @@ class CreateCallableObject(CallableCommand, sd.CreateObject):
 
         return cmd
 
-    def get_resolved_attributes(self, schema: s_schema.Schema, context):
+    def get_resolved_attributes(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> Dict[str, Any]:
         params = self.get_attribute_value('params')
 
         if params is None:
@@ -799,20 +827,29 @@ class CreateCallableObject(CallableCommand, sd.CreateObject):
         return props
 
 
-class DeleteCallableObject(CallableCommand, sd.DeleteObject):
+class DeleteCallableObject(CallableCommand,
+                           sd.DeleteObject[CallableObject]):
 
     @classmethod
-    def _cmd_tree_from_ast(cls, schema: s_schema.Schema, astnode, context):
+    def _cmd_tree_from_ast(
+        cls,
+        schema: s_schema.Schema,
+        astnode: qlast.DDLOperation,
+        context: sd.CommandContext,
+    ) -> sd.Command:
+        assert isinstance(astnode, qlast.ObjectDDL)
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
 
         params = cls._get_param_desc_from_ast(
             schema, context.modaliases, astnode)
 
         for param in params:
+            assert isinstance(cmd.classname, sn.SchemaName)
             cmd.add(param.as_delete_delta(
                 schema, cmd.classname, context=context))
 
-        obj = schema.get(cmd.classname)
+        obj: CallableObject = schema.get(cmd.classname)
+
         return_type = obj.get_return_type(schema)
         if return_type.is_collection():
             s_types.cleanup_schema_collection(
@@ -861,7 +898,8 @@ class Function(CallableObject, VolatilitySubject, s_abc.Function,
     def get_verbosename(
         self,
         schema: s_schema.Schema,
-        *, with_parent: bool=False,
+        *,
+        with_parent: bool=False,
     ) -> str:
         params = self.get_params(schema)
         sn = self.get_shortname(schema)
@@ -880,9 +918,13 @@ class FunctionCommand(CallableCommand,
     def _classname_from_ast(
         cls,
         schema: s_schema.Schema,
-        astnode,
-        context,
-    ):
+        astnode: qlast.NamedDDL,
+        context: sd.CommandContext,
+    ) -> sn.SchemaName:
+        # _classname_from_ast signature expects qlast.NamedDDL,
+        # but _get_param_desc_from_ast expects a ObjectDDL,
+        # which is more specific
+        assert isinstance(astnode, qlast.ObjectDDL)
         name = super()._classname_from_ast(schema, astnode, context)
 
         params = cls._get_param_desc_from_ast(
@@ -893,10 +935,10 @@ class FunctionCommand(CallableCommand,
     def compile_expr_field(
         self,
         schema: s_schema.Schema,
-        context,
-        field,
-        value,
-    ):
+        context: sd.CommandContext,
+        field: so.Field[Any],
+        value: expr.Expression,
+    ) -> expr.Expression:
         if field.name == 'initial_value':
             return type(value).compiled(
                 value,
@@ -911,7 +953,12 @@ class FunctionCommand(CallableCommand,
 class CreateFunction(CreateCallableObject, FunctionCommand):
     astnode = qlast.CreateFunction
 
-    def _create_begin(self, schema: s_schema.Schema, context):
+    def _create_begin(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+    ) -> s_schema.Schema:
+        from edb.ir import ast as irast
         from edb.ir import utils as irutils
 
         fullname = self.classname
@@ -930,6 +977,9 @@ class CreateFunction(CreateCallableObject, FunctionCommand):
         schema = super()._create_begin(schema, context)
 
         params: FuncParameterList = self.scls.get_params(schema)
+
+        assert isinstance(self.scls, (Function, irast.Statement))
+
         language = self.scls.get_language(schema)
         return_type = self.scls.get_return_type(schema)
         return_typemod = self.scls.get_return_typemod(schema)
@@ -1044,6 +1094,7 @@ class CreateFunction(CreateCallableObject, FunctionCommand):
                     f'invalid default value {p_default.text!r} of parameter '
                     f'{p.get_displayname(schema)!r}: {ex}',
                     context=self.source_context)
+            assert isinstance(ir_default, irast.Statement)
 
             check_default_type = True
             if p_type.is_polymorphic(schema):
@@ -1075,8 +1126,14 @@ class CreateFunction(CreateCallableObject, FunctionCommand):
         return schema
 
     @classmethod
-    def _cmd_tree_from_ast(cls, schema: s_schema.Schema, astnode, context):
+    def _cmd_tree_from_ast(
+        cls,
+        schema: s_schema.Schema,
+        astnode: qlast.DDLOperation,
+        context: sd.CommandContext,
+    ) -> sd.Command:
         cmd = super()._cmd_tree_from_ast(schema, astnode, context)
+        assert isinstance(astnode, qlast.CreateFunction)
 
         if astnode.code is not None:
             cmd.set_attribute_value(
@@ -1096,7 +1153,12 @@ class CreateFunction(CreateCallableObject, FunctionCommand):
 
         return cmd
 
-    def _apply_fields_ast(self, schema: s_schema.Schema, context, node):
+    def _apply_fields_ast(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        node: qlast.DDLOperation,
+    ) -> None:
         super()._apply_fields_ast(schema, context, node)
 
         params = []
@@ -1117,32 +1179,41 @@ class CreateFunction(CreateCallableObject, FunctionCommand):
 
         node.params = [p[1] for p in params]
 
-    def _apply_field_ast(self, schema: s_schema.Schema, context, node, op):
+    def _apply_field_ast(
+        self,
+        schema: s_schema.Schema,
+        context: sd.CommandContext,
+        node: qlast.DDLOperation,
+        op: sd.AlterObjectProperty,
+    ) -> None:
+        assert isinstance(node, qlast.CreateFunction)
+        new_value: Any = op.new_value
+
         if op.property == 'return_type':
-            node.returning = utils.typeref_to_ast(schema, op.new_value)
+            node.returning = utils.typeref_to_ast(schema, new_value)
 
         elif op.property == 'return_typemod':
-            node.returning_typemod = op.new_value
+            node.returning_typemod = new_value
 
         elif op.property == 'code':
             if node.code is None:
                 node.code = qlast.FunctionCode()
-            node.code.code = op.new_value
+            node.code.code = new_value
 
         elif op.property == 'language':
             if node.code is None:
                 node.code = qlast.FunctionCode()
-            node.code.language = op.new_value
+            node.code.language = new_value
 
-        elif op.property == 'from_function' and op.new_value:
+        elif op.property == 'from_function' and new_value:
             if node.code is None:
                 node.code = qlast.FunctionCode()
-            node.code.from_function = op.new_value
+            node.code.from_function = new_value
 
-        elif op.property == 'from_expr' and op.new_value:
+        elif op.property == 'from_expr' and new_value:
             if node.code is None:
                 node.code = qlast.FunctionCode()
-            node.code.from_expr = op.new_value
+            node.code.from_expr = new_value
 
         else:
             super()._apply_field_ast(schema, context, node, op)
@@ -1152,7 +1223,8 @@ class RenameFunction(sd.RenameObject, FunctionCommand):
     pass
 
 
-class AlterFunction(sd.AlterObject, FunctionCommand):
+class AlterFunction(AlterCallableObject,
+                    FunctionCommand):
     astnode = qlast.AlterFunction
 
 

--- a/edb/schema/operators.py
+++ b/edb/schema/operators.py
@@ -172,6 +172,7 @@ class CreateOperator(s_func.CreateCallableObject, OperatorCommand):
         fullname = self.scls.get_name(schema)
         shortname = sn.shortname_from_fullname(fullname)
         return_typemod = self.scls.get_return_typemod(schema)
+        assert isinstance(self.scls, Operator)
         recursive = self.scls.get_recursive(schema)
         derivative_of = self.scls.get_derivative_of(schema)
 

--- a/edb/schema/types.py
+++ b/edb/schema/types.py
@@ -2083,7 +2083,7 @@ def ensure_schema_collection(
 def cleanup_schema_collection(
     schema: s_schema.Schema,
     coll_type: Type,
-    parent: Type,
+    parent: so.Object,
     parent_cmd: sd.Command,
     *,
     src_context: Optional[parsing.ParserContext] = None,

--- a/mypy.ini
+++ b/mypy.ini
@@ -580,3 +580,19 @@ no_implicit_optional = True
 warn_unused_ignores = True
 warn_return_any = True
 no_implicit_reexport = True
+
+[mypy-edb.schema.functions]
+follow_imports = True
+ignore_errors = False
+# Equivalent of --strict on the command line:
+disallow_subclassing_any = True
+disallow_any_generics = True
+# disallow_untyped_calls = True
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_unused_ignores = True
+warn_return_any = True
+no_implicit_reexport = True

--- a/tests/test_type_coverage.py
+++ b/tests/test_type_coverage.py
@@ -245,7 +245,7 @@ class TypeCoverageTests(unittest.TestCase):
         self.assertFunctionCoverage(EDB_DIR / "repl", 100.0)
 
     def test_cqa_type_coverage_schema(self) -> None:
-        self.assertFunctionCoverage(EDB_DIR / "schema", 85.11)
+        self.assertFunctionCoverage(EDB_DIR / "schema", 87.44)
 
     def test_cqa_type_coverage_server(self) -> None:
         self.assertFunctionCoverage(EDB_DIR / "server", 14.43)


### PR DESCRIPTION
Adds annotations for schema functions, including a small refactoring of how `get_shortname` is used in `Parameter` class: its signature is made consistent with the one inherited from `QualifiedObject`, and replaces the places where it is used with a new function `get_parameter_name`.