### PR TITLE
Clamp datetime, local_datetime and local_date to the 1-9999 year rang…

### DIFF
--- a/edb/lib/std/30-datetimefuncs.edgeql
+++ b/edb/lib/std/30-datetimefuncs.edgeql
@@ -98,12 +98,12 @@ std::datetime_truncate(dt: std::datetime, unit: std::str) -> std::datetime
             'microseconds', 'milliseconds', 'seconds',
             'minutes', 'hours', 'days', 'weeks', 'months',
             'years', 'decades', 'centuries')
-        THEN date_trunc("unit", "dt")
+        THEN date_trunc("unit", "dt")::edgedb.timestamptz_t
         WHEN "unit" = 'quarters'
-        THEN date_trunc('quarter', "dt")
+        THEN date_trunc('quarter', "dt")::edgedb.timestamptz_t
         ELSE
             edgedb.raise(
-                NULL::timestamptz,
+                NULL::edgedb.timestamptz_t,
                 'invalid_datetime_format',
                 msg => (
                     'invalid unit for std::datetime_truncate: '
@@ -171,7 +171,7 @@ std::`=` (l: std::datetime, r: std::datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
     SET commutator := 'std::=';
     SET negator := 'std::!=';
-    USING SQL OPERATOR r'=';
+    USING SQL OPERATOR r'=(timestamptz,timestamptz)';
 };
 
 
@@ -187,7 +187,7 @@ std::`!=` (l: std::datetime, r: std::datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
     SET commutator := 'std::!=';
     SET negator := 'std::=';
-    USING SQL OPERATOR r'<>';
+    USING SQL OPERATOR r'<>(timestamptz,timestamptz)';
 };
 
 
@@ -203,7 +203,7 @@ std::`>` (l: std::datetime, r: std::datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
     SET commutator := 'std::<';
     SET negator := 'std::<=';
-    USING SQL OPERATOR r'>';
+    USING SQL OPERATOR r'>(timestamptz,timestamptz)';
 };
 
 
@@ -212,7 +212,7 @@ std::`>=` (l: std::datetime, r: std::datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
     SET commutator := 'std::<=';
     SET negator := 'std::<';
-    USING SQL OPERATOR r'>=';
+    USING SQL OPERATOR r'>=(timestamptz,timestamptz)';
 };
 
 
@@ -221,7 +221,7 @@ std::`<` (l: std::datetime, r: std::datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
     SET commutator := 'std::>';
     SET negator := 'std::>=';
-    USING SQL OPERATOR r'<';
+    USING SQL OPERATOR r'<(timestamptz,timestamptz)';
 };
 
 
@@ -230,7 +230,7 @@ std::`<=` (l: std::datetime, r: std::datetime) -> std::bool {
     SET volatility := 'IMMUTABLE';
     SET commutator := 'std::>=';
     SET negator := 'std::>';
-    USING SQL OPERATOR r'<=';
+    USING SQL OPERATOR r'<=(timestamptz,timestamptz)';
 };
 
 
@@ -239,7 +239,9 @@ std::`+` (l: std::datetime, r: std::duration) -> std::datetime {
     # operators on timestamptz are STABLE in PostgreSQL
     SET volatility := 'STABLE';
     SET commutator := 'std::+';
-    USING SQL OPERATOR r'+';
+    USING SQL $$
+        SELECT ("l" + "r")::edgedb.timestamptz_t
+    $$
 };
 
 
@@ -248,7 +250,9 @@ std::`+` (l: std::duration, r: std::datetime) -> std::datetime {
     # operators on timestamptz are STABLE in PostgreSQL
     SET volatility := 'STABLE';
     SET commutator := 'std::+';
-    USING SQL OPERATOR r'+';
+    USING SQL $$
+        SELECT ("l" + "r")::edgedb.timestamptz_t
+    $$
 };
 
 
@@ -256,7 +260,9 @@ CREATE INFIX OPERATOR
 std::`-` (l: std::datetime, r: std::duration) -> std::datetime {
     # operators on timestamptz are STABLE in PostgreSQL
     SET volatility := 'STABLE';
-    USING SQL OPERATOR r'-';
+    USING SQL $$
+        SELECT ("l" - "r")::edgedb.timestamptz_t
+    $$
 };
 
 

--- a/edb/lib/std/70-converters.edgeql
+++ b/edb/lib/std/70-converters.edgeql
@@ -283,7 +283,7 @@ std::to_datetime(s: std::str, fmt: OPTIONAL str={}) -> std::datetime
             edgedb.datetime_in("s")
         WHEN "fmt" = '' THEN
             edgedb.raise(
-                NULL::timestamptz,
+                NULL::edgedb.timestamptz_t,
                 'invalid_parameter_value',
                 msg => (
                     'to_datetime(): "fmt" argument must be a non-empty string'
@@ -313,7 +313,7 @@ std::to_datetime(year: std::int64, month: std::int64, day: std::int64,
     SELECT make_timestamptz(
         "year"::int, "month"::int, "day"::int,
         "hour"::int, "min"::int, "sec", "timezone"
-    )
+    )::edgedb.timestamptz_t
     $$;
 };
 
@@ -324,7 +324,7 @@ std::to_datetime(epochseconds: std::float64) -> std::datetime
     CREATE ANNOTATION std::description := 'Create a `datetime` value.';
     SET volatility := 'STABLE';
     USING SQL $$
-    SELECT to_timestamp("epochseconds")
+    SELECT to_timestamp("epochseconds")::edgedb.timestamptz_t
     $$;
 };
 
@@ -335,7 +335,7 @@ std::to_datetime(epochseconds: std::int64) -> std::datetime
     CREATE ANNOTATION std::description := 'Create a `datetime` value.';
     SET volatility := 'STABLE';
     USING SQL $$
-    SELECT to_timestamp("epochseconds")
+    SELECT to_timestamp("epochseconds")::edgedb.timestamptz_t
     $$;
 };
 
@@ -346,7 +346,7 @@ std::to_datetime(epochseconds: std::decimal) -> std::datetime
     CREATE ANNOTATION std::description := 'Create a `datetime` value.';
     SET volatility := 'STABLE';
     USING SQL $$
-    SELECT to_timestamp("epochseconds")
+    SELECT to_timestamp("epochseconds")::edgedb.timestamptz_t
     $$;
 };
 

--- a/edb/pgsql/types.py
+++ b/edb/pgsql/types.py
@@ -48,13 +48,13 @@ base_type_name_map = {
     s_obj.get_known_type_id('std::float64'): ('float8',),
     s_obj.get_known_type_id('std::float32'): ('float4',),
     s_obj.get_known_type_id('std::uuid'): ('uuid',),
-    s_obj.get_known_type_id('std::datetime'): ('timestamptz',),
+    s_obj.get_known_type_id('std::datetime'): ('edgedb', 'timestamptz_t'),
     s_obj.get_known_type_id('std::duration'): ('interval',),
     s_obj.get_known_type_id('std::bytes'): ('bytea',),
     s_obj.get_known_type_id('std::json'): ('jsonb',),
 
-    s_obj.get_known_type_id('cal::local_datetime'): ('timestamp',),
-    s_obj.get_known_type_id('cal::local_date'): ('date',),
+    s_obj.get_known_type_id('cal::local_datetime'): ('edgedb', 'timestamp_t'),
+    s_obj.get_known_type_id('cal::local_date'): ('edgedb', 'date_t'),
     s_obj.get_known_type_id('cal::local_time'): ('time',),
 }
 
@@ -79,13 +79,19 @@ base_type_name_map_r = {
     'float4': sn.QualName('std', 'float32'),
     'uuid': sn.QualName('std', 'uuid'),
     'timestamp with time zone': sn.QualName('std', 'datetime'),
+    'edgedb.timestamptz_t': sn.QualName('std', 'datetime'),
+    'timestamptz_t': sn.QualName('std', 'datetime'),
     'timestamptz': sn.QualName('std', 'datetime'),
     'interval': sn.QualName('std', 'duration'),
     'bytea': sn.QualName('std', 'bytes'),
     'jsonb': sn.QualName('std', 'json'),
 
     'timestamp': sn.QualName('cal', 'local_datetime'),
+    'timestamp_t': sn.QualName('cal', 'local_datetime'),
+    'edgedb.timestamp_t': sn.QualName('cal', 'local_datetime'),
     'date': sn.QualName('cal', 'local_date'),
+    'date_t': sn.QualName('cal', 'local_date'),
+    'edgedb.date_t': sn.QualName('cal', 'local_date'),
     'time': sn.QualName('cal', 'local_time'),
 }
 

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -34,7 +34,7 @@ EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 EDGEDB_SPECIAL_DBS = {EDGEDB_TEMPLATE_DB, EDGEDB_SYSTEM_DB}
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2021_02_15_00_00
+EDGEDB_CATALOG_VERSION = 2021_02_19_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/tests/test_edgeql_datatypes.py
+++ b/tests/test_edgeql_datatypes.py
@@ -186,6 +186,77 @@ class TestEdgeQLDT(tb.QueryTestCase):
             [-timedelta(seconds=24674, microseconds=45854)],
         )
 
+    async def test_edgeql_dt_duration_07_datetime_range(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.InvalidValueError,
+            'value out of range',
+        ):
+            await self.con.execute(
+                """
+                SELECT <datetime>'9999-12-31T00:00:00Z' + <duration>'30 hours'
+                """
+            )
+
+        async with self.assertRaisesRegexTx(
+            edgedb.InvalidValueError,
+            'value out of range',
+        ):
+            await self.con.execute(
+                """
+                SELECT <datetime>'0001-01-01T00:00:00Z' - <duration>'30 hours'
+                """
+            )
+
+    async def test_edgeql_dt_duration_08_local_datetime_range(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.InvalidValueError,
+            'value out of range',
+        ):
+            await self.con.execute(
+                """
+                SELECT
+                    <cal::local_datetime>'9999-12-31T00:00:00'
+                    + <duration>'30 hours'
+                """
+            )
+
+        async with self.assertRaisesRegexTx(
+            edgedb.InvalidValueError,
+            'value out of range',
+        ):
+            await self.con.execute(
+                """
+                SELECT
+                    <cal::local_datetime>'0001-01-01T00:00:00'
+                    - <duration>'30 hours'
+                """
+            )
+
+    async def test_edgeql_dt_duration_09_local_date_range(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.InvalidValueError,
+            'value out of range',
+        ):
+            await self.con.execute(
+                """
+                SELECT
+                    <cal::local_date>'9999-12-31'
+                    + <duration>'30 hours'
+                """
+            )
+
+        async with self.assertRaisesRegexTx(
+            edgedb.InvalidValueError,
+            'value out of range',
+        ):
+            await self.con.execute(
+                """
+                SELECT
+                    <cal::local_date>'0001-01-01'
+                    - <duration>'30 hours'
+                """
+            )
+
     async def test_edgeql_dt_local_datetime_01(self):
         await self.assert_query_result(
             r'''

--- a/tests/test_edgeql_functions.py
+++ b/tests/test_edgeql_functions.py
@@ -1008,6 +1008,15 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
         )
         self.assertEqual('1986-05-30T00:00:00+00:00', dt)
 
+    async def test_edgeql_functions_unix_to_datetime_05(self):
+        with self.assertRaisesRegex(
+            edgedb.InvalidValueError,
+            "'std::datetime' value out of range"
+        ):
+            await self.con.query_one(
+                'SELECT to_datetime(999999999999)'
+            )
+
     async def test_edgeql_functions_datetime_current_01(self):
         # make sure that datetime as a str gets serialized to a
         # particular format
@@ -1508,6 +1517,31 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
                         to_datetime('2019/01/01 00:00:00');
                 ''')
 
+    async def test_edgeql_functions_to_datetime_06(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.InvalidValueError,
+            'value out of range',
+        ):
+            await self.con.query(r'''
+                SELECT to_datetime(10000, 1, 1, 1, 1, 1, 'UTC');
+            ''')
+
+        async with self.assertRaisesRegexTx(
+            edgedb.InvalidValueError,
+            'value out of range',
+        ):
+            await self.con.query(r'''
+                SELECT to_datetime(0, 1, 1, 1, 1, 1, 'UTC');
+            ''')
+
+        async with self.assertRaisesRegexTx(
+            edgedb.InvalidValueError,
+            'value out of range',
+        ):
+            await self.con.query(r'''
+                SELECT to_datetime(-1, 1, 1, 1, 1, 1, 'UTC');
+            ''')
+
     async def test_edgeql_functions_to_local_datetime_01(self):
         await self.assert_query_result(
             r'''
@@ -1588,6 +1622,31 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
                         cal::to_local_datetime('2019/01/01 00:00:00 0715');
                 ''')
 
+    async def test_edgeql_functions_to_local_datetime_07(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.InvalidValueError,
+            'value out of range',
+        ):
+            await self.con.query(r'''
+                SELECT cal::to_local_datetime(10000, 1, 1, 1, 1, 1);
+            ''')
+
+        async with self.assertRaisesRegexTx(
+            edgedb.InvalidValueError,
+            'value out of range',
+        ):
+            await self.con.query(r'''
+                SELECT cal::to_local_datetime(0, 1, 1, 1, 1, 1);
+            ''')
+
+        async with self.assertRaisesRegexTx(
+            edgedb.InvalidValueError,
+            'value out of range',
+        ):
+            await self.con.query(r'''
+                SELECT cal::to_local_datetime(-1, 1, 1, 1, 1, 1);
+            ''')
+
     async def test_edgeql_functions_to_local_date_01(self):
         await self.assert_query_result(
             r'''
@@ -1631,8 +1690,33 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
                 # including too much
                 await self.con.query(r'''
                     SELECT
-                        cal::to_local_datetime('2019/01/01 00:00:00 0715');
+                        cal::to_local_date('2019/01/01 00:00:00 0715');
                 ''')
+
+    async def test_edgeql_functions_to_local_date_05(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.InvalidValueError,
+            'value out of range',
+        ):
+            await self.con.query(r'''
+                SELECT cal::to_local_date(10000, 1, 1);
+            ''')
+
+        async with self.assertRaisesRegexTx(
+            edgedb.InvalidValueError,
+            'value out of range',
+        ):
+            await self.con.query(r'''
+                SELECT cal::to_local_date(0, 1, 1);
+            ''')
+
+        async with self.assertRaisesRegexTx(
+            edgedb.InvalidValueError,
+            'value out of range',
+        ):
+            await self.con.query(r'''
+                SELECT cal::to_local_date(-1, 1, 1);
+            ''')
 
     async def test_edgeql_functions_to_local_time_01(self):
         await self.assert_query_result(
@@ -1679,6 +1763,15 @@ class TestEdgeQLFunctions(tb.QueryTestCase):
                     SELECT
                         cal::to_local_datetime('00:00:00 0715');
                 ''')
+
+    async def test_edgeql_functions_to_local_time_05(self):
+        async with self.assertRaisesRegexTx(
+            edgedb.InvalidValueError,
+            'value out of range',
+        ):
+            await self.con.query(r'''
+                SELECT cal::to_local_datetime(10000, 1, 1, 1, 1, 1);
+            ''')
 
     async def test_edgeql_functions_to_duration_01(self):
         await self.assert_query_result(


### PR DESCRIPTION
…e (#2252)

The default timestamp range of (4713 BC - 294276 AD) has problems:
Postgres isn't ISO compliant with years out of the 0-9999 range and
language compatibility is questionable.

See https://github.com/edgedb/edgedb/pull/2249#issuecomment-782353029
for an expanded rationale.