### PR TITLE
Populate scls in init_delta_command (#2425)

### DIFF
--- a/edb/schema/delta.py
+++ b/edb/schema/delta.py
@@ -1802,7 +1802,6 @@ class ObjectCommand(Command, Generic[so.Object_T]):
                         schema, context, cmdtype=AlterObject)
                     delta_create, cmd_create, _ = ref.init_delta_branch(
                         schema, context, cmdtype=AlterObject)
-                    cmd_create.scls = ref
                     # Mark it metadata_only so that if it actually gets
                     # applied, only the metadata is changed but not
                     # the real underlying schema.

--- a/edb/schema/objects.py
+++ b/edb/schema/objects.py
@@ -1504,6 +1504,7 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
             ddl_identity=self.get_ddl_identity(schema),
             **kwargs,
         )
+        cmd.scls = self
         self.record_cmd_object_aux_data(schema, cmd)
         return cmd
 
@@ -1573,7 +1574,6 @@ class Object(s_abc.Object, ObjectContainer, metaclass=ObjectMeta):
             classname=classname,
             **kwargs,
         )
-        self_cmd.scls = self
 
         parent_cmd.add(self_cmd)
         ctx_stack.push(self_cmd.new_context(schema, context, self))

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -5646,6 +5646,28 @@ class TestGetMigration(tb.BaseSchemaLoadTest):
             type Person2a;
         """])
 
+    def test_schema_migrations_drop_from_one_parent_01(self):
+        self._assert_migration_equivalence([r"""
+            abstract type Text { property x -> str { constraint exclusive } }
+            abstract type Owned { property x -> str { constraint exclusive } }
+            type Comment extending Text, Owned;
+        """, r"""
+            abstract type Text { }
+            abstract type Owned { property x -> str { constraint exclusive } }
+            type Comment extending Text, Owned;
+        """])
+
+    def test_schema_migrations_drop_from_one_parent_02(self):
+        self._assert_migration_equivalence([r"""
+            abstract type Text { property x -> str { constraint exclusive } }
+            abstract type Owned { property x -> str { constraint exclusive } }
+            type Comment extending Text, Owned;
+        """, r"""
+            abstract type Text { property x -> str }
+            abstract type Owned { property x -> str { constraint exclusive } }
+            type Comment extending Text, Owned;
+        """])
+
 
 class TestDescribe(tb.BaseSchemaLoadTest):
     """Test the DESCRIBE command."""


### PR DESCRIPTION
Currently we are populating it in init_delta_branch but not
init_delta_command. This caused a bug when rebasing constraints
because of a drop in one parent where an scls was expected
but not present.