### PR TITLE
Push shapes further down in the IR tree when possible (#2453)

### DIFF
--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -100,7 +100,7 @@ class OffsetLimitMixin(Base):
 
 class OrderByMixin(Base):
     __abstract_node__ = True
-    orderby: typing.Optional[typing.List[SortExpr]]
+    orderby: typing.List[SortExpr]
 
 
 class FilterMixin(Base):

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -156,15 +156,6 @@ def compile_ForQuery(
                 context=ctx.env.type_origins.get(anytype),
             )
 
-        # If this statement is exposed, and there is a shape-induced
-        # iterator context, then register the iterator as hoisted.
-        # This ensures that the pgsql compiler allows the iterator value
-        # to drift upward. Note that sctx.iterator_ctx.stmt may equal stmt
-        # and also that I think this whole mechanism is subtly wrong.
-        if (sctx.expr_exposed and sctx.iterator_ctx is not None
-                and sctx.iterator_ctx.stmt is not None):
-            sctx.iterator_ctx.stmt.hoisted_iterators.append(iterator_stmt)
-
         view_scope_info = sctx.path_scope_map[iterator_view]
 
         pathctx.register_set_in_scope(

--- a/edb/ir/ast.py
+++ b/edb/ir/ast.py
@@ -732,7 +732,6 @@ class Stmt(Expr):
     result: Set
     parent_stmt: typing.Optional[Stmt]
     iterator_stmt: typing.Optional[Set]
-    hoisted_iterators: typing.List[Set]
     bindings: typing.List[Set]
 
 

--- a/edb/ir/utils.py
+++ b/edb/ir/utils.py
@@ -289,17 +289,6 @@ def get_nearest_dml_stmt(ir_set: irast.Set) -> Optional[irast.MutatingStmt]:
     return None
 
 
-def get_iterator_sets(stmt: irast.Stmt) -> Sequence[irast.Set]:
-    iterators = []
-    if stmt.iterator_stmt is not None:
-        if stmt.iterator_stmt not in stmt.hoisted_iterators:
-            iterators.append(stmt.iterator_stmt)
-    if stmt.hoisted_iterators:
-        iterators.extend(stmt.hoisted_iterators)
-
-    return iterators
-
-
 class ContainsDMLVisitor(ast.NodeVisitor):
     skip_hidden = True
 

--- a/edb/pgsql/compiler/expr.py
+++ b/edb/pgsql/compiler/expr.py
@@ -101,11 +101,7 @@ def _compile_set_impl(
         pathctx.put_path_value_var(ctx.rel, ir_set.path_id, value, env=ctx.env)
         if (output.in_serialization_ctx(ctx) and ir_set.shape
                 and not ctx.env.ignore_object_shapes):
-            _compile_shape(
-                ir_set,
-                shape=[expr for expr, _ in ir_set.shape],
-                ctx=ctx,
-            )
+            _compile_shape(ir_set, ir_set.shape, ctx=ctx)
 
     elif ir_set.path_scope_id is not None and not is_toplevel:
         # This Set is behind a scope fence, so compute it
@@ -594,15 +590,23 @@ def _compile_set(
 
     if (output.in_serialization_ctx(ctx) and ir_set.shape
             and not ctx.env.ignore_object_shapes):
-        _compile_shape(
-            ir_set,
-            shape=[expr for expr, _ in ir_set.shape],
-            ctx=ctx,
-        )
+        _compile_shape(ir_set, ir_set.shape, ctx=ctx)
+    elif ir_set.shape and ir_set in ctx.shapes_needed_by_dml:
+        # If this shape is needed for DML purposes (because it is
+        # populating link properties), compile it and populate its
+        # elements as *values*, so that process_link_values can pick
+        # them up and insert them.
+        shape_tuple = shapecomp.compile_shape(ir_set, ir_set.shape, ctx=ctx)
+        for element in shape_tuple.elements:
+            pathctx.put_path_var_if_not_exists(
+                ctx.rel, element.path_id, element.val,
+                aspect='value', env=ctx.env)
 
 
 def _compile_shape(
-        ir_set: irast.Set, shape: List[irast.Set], *,
+        ir_set: irast.Set,
+        shape: List[Tuple[irast.Set, qlast.ShapeOp]],
+        *,
         ctx: context.CompilerContextLevel) -> pgast.TupleVar:
 
     result = shapecomp.compile_shape(ir_set, shape, ctx=ctx)

--- a/edb/pgsql/compiler/relctx.py
+++ b/edb/pgsql/compiler/relctx.py
@@ -718,17 +718,10 @@ def update_scope(
         assert p.path_id is not None
         ctx.path_scope[p.path_id] = stmt
 
-    if isinstance(ir_set.expr, irast.Stmt):
-        iterators = ir_set.expr.hoisted_iterators
-        iter_paths = {it.path_id for it in iterators}
-    else:
-        iter_paths = set()
-
     for child_path in scope_tree.get_all_paths():
         parent_scope = scope_tree.parent
-        if ((parent_scope is None or
-                not parent_scope.is_visible(child_path)) and
-                child_path not in iter_paths):
+        if (parent_scope is None or
+                not parent_scope.is_visible(child_path)):
             stmt.path_id_mask.add(child_path)
 
 

--- a/edb/pgsql/compiler/shapecomp.py
+++ b/edb/pgsql/compiler/shapecomp.py
@@ -23,6 +23,9 @@ from __future__ import annotations
 
 from typing import *
 
+from edb.edgeql import ast as qlast
+
+
 from edb.ir import ast as irast
 from edb.ir import utils as irutils
 
@@ -36,7 +39,8 @@ from . import relgen
 
 
 def compile_shape(
-        ir_set: irast.Set, shape: List[irast.Set], *,
+        ir_set: irast.Set,
+        shape: List[Tuple[irast.Set, qlast.ShapeOp]], *,
         ctx: context.CompilerContextLevel) -> pgast.TupleVar:
     elements = []
 
@@ -44,7 +48,6 @@ def compile_shape(
         shapectx.disable_semi_join.add(ir_set.path_id)
 
         if isinstance(ir_set.expr, irast.Stmt):
-            iterators = irutils.get_iterator_sets(ir_set.expr)
             # The source set for this shape is a FOR statement,
             # which is special in that besides set path_id it
             # should also expose the path_id of the FOR iterator
@@ -58,11 +61,11 @@ def compile_shape(
             #
             # the path scope when processing the shape of Bar.foo
             # should be {'Bar.foo', 'x'}.
-            if iterators:
-                for iterator in iterators:
-                    shapectx.path_scope[iterator.path_id] = ctx.rel
+            iterator = ir_set.expr.iterator_stmt
+            if iterator:
+                shapectx.path_scope[iterator.path_id] = ctx.rel
 
-        for el in shape:
+        for el, _ in shape:
             rptr = el.rptr
             assert rptr is not None
             ptrref = rptr.ptrref

--- a/edb/pgsql/compiler/stmt.py
+++ b/edb/pgsql/compiler/stmt.py
@@ -59,21 +59,21 @@ def compile_SelectStmt(
 
         query = ctx.stmt
 
-        iterators = irutils.get_iterator_sets(stmt)
+        iterator_set = stmt.iterator_stmt
         last_iterator: Optional[irast.Set] = None
-        if iterators and irutils.contains_dml(stmt):
+        if iterator_set and irutils.contains_dml(stmt):
             # If we have iterators and we contain nested DML
             # statements, we need to hoist the iterators into CTEs and
             # then explicitly join them back into the query.
-            iterator = dml.compile_iterator_ctes(iterators, ctx=ctx)
+            iterator = dml.compile_iterator_cte(iterator_set, ctx=ctx)
             ctx.path_scope = ctx.path_scope.new_child()
             dml.merge_iterator(iterator, ctx.rel, ctx=ctx)
 
             ctx.enclosing_cte_iterator = iterator
-            last_iterator = iterators[-1]
+            last_iterator = stmt.iterator_stmt
 
         else:
-            for iterator_set in iterators:
+            if iterator_set:
                 # Process FOR clause.
                 with ctx.new() as ictx:
                     clauses.setup_iterator_volatility(last_iterator, ctx=ictx)

--- a/tests/test_edgeql_ir_scopetree.py
+++ b/tests/test_edgeql_ir_scopetree.py
@@ -311,7 +311,8 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                 "FENCE": {
                     "[ns~1]@[ns~2]@@(test::User).>friends[IS test::User]"
                 },
-                "(test::User).>friends[IS test::User]"
+                "(test::User).>friends[IS test::User]",
+                "[ns~1]@[ns~2]@@(__derived__::expr~13)"
             },
             "FENCE": {
                 "(test::User).>name[IS std::str]"
@@ -677,7 +678,8 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                         }
                     }
                 },
-                "(test::User).>select_deck[IS test::Card]"
+                "(test::User).>select_deck[IS test::Card]",
+                "[ns~1]@[ns~4]@@(__derived__::expr~26)"
             },
             "FENCE": {
                 "(test::User).>name[IS std::str]"
@@ -716,10 +718,10 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
 .>deck[IS test::Card].>name[IS std::str]"
                             }
                         }
-                    },
-                    "[ns~1]@[ns~5]@@(__derived__::__derived__|foo@w~2)"
+                    }
                 },
-                "(test::User).>select_deck[IS test::Card]"
+                "(test::User).>select_deck[IS test::Card]",
+                "[ns~1]@[ns~5]@@(__derived__::__derived__|foo@w~2)"
             },
             "FENCE": {
                 "(test::User).>name[IS std::str]"
@@ -747,7 +749,8 @@ class TestEdgeQLIRScopeTree(tb.BaseEdgeQLCompilerTest):
                 },
                 "(test::User).>deck[IS test::Card]",
                 "FENCE": {
-                    "(test::User).>deck[IS test::Card].>cost[IS std::int64]"
+                    "[ns~1]@[ns~2]@[ns~5]@[ns~6]@@(test::Card)\
+.>cost[IS std::int64]"
                 }
             }
         }

--- a/tests/test_edgeql_scope.py
+++ b/tests/test_edgeql_scope.py
@@ -703,6 +703,16 @@ class TestEdgeQLScope(tb.QueryTestCase):
             ]
         )
 
+    async def test_edgeql_scope_tuple_15(self):
+        res = await self.con.query(r"""
+            WITH MODULE test
+            SELECT ((SELECT User {deck}), User.deck);
+        """)
+
+        # The deck shape ought to contain just the correlated element
+        for row in res:
+            self.assertEqual(row[0].deck, [row[1]])
+
     async def test_edgeql_scope_binding_01(self):
         await self.assert_query_result(
             r"""

--- a/tests/test_http_graphql_schema.py
+++ b/tests/test_http_graphql_schema.py
@@ -2356,14 +2356,9 @@ class TestGraphQLSchema(tb.GraphQLTestCase):
                     {
                         "name": "of_group",
                         "type": {
-                            "kind": "NON_NULL",
-                            "name": None,
-                            "ofType": {
-                                "kind": "OBJECT",
-                                "name":
-                                    "_edb__SettingAliasAugmented__of_group",
-                                "__typename": "__Type"
-                            },
+                            "kind": "OBJECT",
+                            "name": "_edb__SettingAliasAugmented__of_group",
+                            "ofType": None,
                             "__typename": "__Type"
                         },
                         "__typename": "__Field",


### PR DESCRIPTION
This avoids bugs with queries like
`SELECT ((SELECT User {deck}), User.deck)`,
which was being miscompiled as if it was
`SELECT ((SELECT User) {deck}, User.deck)`

It also allows us to ditch the entire `hoisted_iterator` mechanism,
since we no longer need to hoist iterators above hoisted shapes!