### PR TITLE
Allow generate cert with --bootstrap-only (#2689)

### DIFF
--- a/edb/server/args.py
+++ b/edb/server/args.py
@@ -93,6 +93,7 @@ class ServerConfig(NamedTuple):
 
     tls_cert_file: Optional[pathlib.Path]
     tls_key_file: Optional[pathlib.Path]
+    generate_self_signed_cert: bool
     allow_cleartext_connections: bool
 
 
@@ -484,7 +485,7 @@ def parse_args(**kwargs: Any):
                 if (tls_key_file := data_dir / TLS_KEY_FILE_NAME).exists():
                     kwargs['tls_key_file'] = tls_key_file
     if (
-        not kwargs.pop('generate_self_signed_cert')
+        not kwargs['generate_self_signed_cert']
         and not kwargs['tls_cert_file']
         and not kwargs['bootstrap_only']
     ):

--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -245,7 +245,7 @@ class BaseCluster:
             asyncio.run(test())
             left -= (time.monotonic() - started)
 
-        if self._admin_query("SELECT ();", f"{min(1, int(left))}s"):
+        if self._admin_query("SELECT ();", f"{max(1, int(left))}s"):
             raise ClusterError(
                 f'could not connect to edgedb-server '
                 f'within {timeout} seconds') from None
@@ -253,9 +253,7 @@ class BaseCluster:
     def _admin_query(self, query, wait_until_available="0s"):
         return subprocess.call(
             [
-                sys.executable,
-                "-m",
-                "edb.cli",
+                "edgedb",
                 "--host",
                 str(self._runstate_dir),
                 "--port",


### PR DESCRIPTION
Also generate certs in the internal_runstate_dir:

If there is no data_dir when --generate-self-signed-cert is set, the
generated cert files are now stored in the internal_runstate_dir rather
than another temporary directory.

Also fixed 2 admin query issues in the test (edgedb PATH and timeout)