### PR TITLE
Fix issue that --bootstrap-command is executed twice

### DIFF
--- a/edb/server/main.py
+++ b/edb/server/main.py
@@ -203,10 +203,9 @@ async def _run_server(
                 )
             )
 
-        if args.startup_script:
-            await sc.wait_for(ss.run_startup_script_and_exit())
-
         if args.bootstrap_only:
+            if args.startup_script:
+                await sc.wait_for(ss.run_startup_script_and_exit())
             return
 
         if not args.generate_self_signed_cert:

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -132,6 +132,23 @@ class TestServerOps(tb.TestCase):
                     'Unexpected server error output:\n' + stderr.decode()
                 )
 
+    async def test_server_ops_bootstrap_script_server(self):
+        # Test that "edgedb-server" works as expected with the
+        # following arguments:
+        #
+        # * "--bootstrap-command"
+
+        async with tb.start_edgedb_server(
+            auto_shutdown=True,
+            bootstrap_command='CREATE SUPERUSER ROLE test_bootstrap2 '
+                              '{ SET password := "tbs2" };'
+        ) as sd:
+            con = await sd.connect(user='test_bootstrap2', password='tbs2')
+            try:
+                self.assertEqual(await con.query_one('SELECT 1'), 1)
+            finally:
+                await con.aclose()
+
     async def test_server_ops_emit_server_status_to_file(self):
         debug = False
 


### PR DESCRIPTION
A bug was introduced in #2689 that if --bootstrap-command or
--bootstrap-script is set without --bootstrap-only, the startup script
will be executed twice.