### PR TITLE
Rename CONFIGURE SYSTEM to CONFIGURE INSTANCE

### DIFF
--- a/docs/admin/configuration.rst
+++ b/docs/admin/configuration.rst
@@ -19,7 +19,7 @@ parameters using EdgeQL.  For example:
 
 .. code-block:: edgeql
 
-    CONFIGURE SYSTEM SET listen_addresses := {'127.0.0.1', '::1'};
+    CONFIGURE INSTANCE SET listen_addresses := {'127.0.0.1', '::1'};
 
 
 edgedb configure

--- a/docs/changelog/1_0_a4.rst
+++ b/docs/changelog/1_0_a4.rst
@@ -19,7 +19,7 @@ EdgeQL
 * Only show link properties on link computables that are aliases.
 * :eql:stmt:`DESCRIBE` command now shows matches that are potentially
   masked by the user-defined types or functions (:eql:gh:`#1439`).
-* Add ``DESCRIBE ROLES`` and ``DESCRIBE SYSTEM CONFIG`` to the
+* Add ``DESCRIBE ROLES`` and ``DESCRIBE INSTANCE CONFIG`` to the
   :eql:stmt:`DESCRIBE` command.
 * Allow underscore in numeric literals and forbids float and decimal
   constants to end in ``.`` (:eql:gh:`#920`).

--- a/docs/cheatsheet/admin.rst
+++ b/docs/cheatsheet/admin.rst
@@ -29,7 +29,7 @@ Configure passwordless access (such as to a local development database):
 
 .. code-block:: edgeql-repl
 
-    db> CONFIGURE SYSTEM INSERT Auth {
+    db> CONFIGURE INSTANCE INSERT Auth {
     ...     # Human-oriented comment helps figuring out
     ...     # what authentication methods have been setup
     ...     # and makes it easier to identify them.
@@ -37,7 +37,7 @@ Configure passwordless access (such as to a local development database):
     ...     priority := 1,
     ...     method := (INSERT Trust),
     ... };
-    CONFIGURE SYSTEM
+    CONFIGURE INSTANCE
 
 
 ----------
@@ -59,12 +59,12 @@ Configure access that checks password (with a higher priority):
 
 .. code-block:: edgeql-repl
 
-    db> CONFIGURE SYSTEM INSERT Auth {
+    db> CONFIGURE INSTANCE INSERT Auth {
     ...     comment := 'password is required',
     ...     priority := 0,
     ...     method := (INSERT SCRAM),
     ... };
-    CONFIGURE SYSTEM
+    CONFIGURE INSTANCE
 
 
 ----------
@@ -74,9 +74,9 @@ Remove a specific authentication method:
 
 .. code-block:: edgeql-repl
 
-    db> CONFIGURE SYSTEM RESET Auth
+    db> CONFIGURE INSTANCE RESET Auth
     ... FILTER .comment = 'password is required';
-    CONFIGURE SYSTEM
+    CONFIGURE INSTANCE
 
 
 ----------

--- a/docs/cheatsheet/cli.rst
+++ b/docs/cheatsheet/cli.rst
@@ -43,7 +43,7 @@ Configure passwordless access (such as to a local development database):
     > --comment 'passwordless access' \
     > --priority 1 \
     > --method Trust
-    OK: CONFIGURE SYSTEM
+    OK: CONFIGURE INSTANCE
 
 
 ----------
@@ -70,7 +70,7 @@ Configure access that checks password (with a higher priority):
     > --comment 'password is required' \
     > --priority 0 \
     > --method SCRAM
-    OK: CONFIGURE SYSTEM
+    OK: CONFIGURE INSTANCE
 
 
 ----------

--- a/docs/edgeql/admin/configure.rst
+++ b/docs/edgeql/admin/configure.rst
@@ -10,11 +10,11 @@ CONFIGURE
 
 .. eql:synopsis::
 
-    CONFIGURE {SESSION | CURRENT DATABASE | SYSTEM}
+    CONFIGURE {SESSION | CURRENT DATABASE | INSTANCE}
         SET <parameter> := <value> ;
-    CONFIGURE SYSTEM INSERT <parameter-class> <insert-shape> ;
-    CONFIGURE {SESSION | CURRENT DATABASE | SYSTEM} RESET <parameter> ;
-    CONFIGURE {CURRENT DATABASE | SYSTEM}
+    CONFIGURE INSTANCE INSERT <parameter-class> <insert-shape> ;
+    CONFIGURE {SESSION | CURRENT DATABASE | INSTANCE} RESET <parameter> ;
+    CONFIGURE {CURRENT DATABASE | INSTANCE}
         RESET <parameter-class> [ FILTER <filter-expr> ] ;
 
 
@@ -26,18 +26,18 @@ This command allows altering the server configuration.
 The effects of :eql:synopsis:`CONFIGURE SESSION` last until the end of the
 current session. Some configuration parameters cannot be modified by
 :eql:synopsis:`CONFIGURE SESSION` and can only be set by
-:eql:synopsis:`CONFIGURE SYSTEM`.
+:eql:synopsis:`CONFIGURE INSTANCE`.
 
 :eql:synopsis:`CONFIGURE CURRENT DATABASE` is used to configure an
 individual EdgeDB database within a server instance with the
 changes persisted across server restarts.
 
-:eql:synopsis:`CONFIGURE SYSTEM` is used to configure the entire EdgeDB
+:eql:synopsis:`CONFIGURE INSTANCE` is used to configure the entire EdgeDB
 instance with the changes persisted across server restarts.  This variant
 acts directly on the file system and cannot be rolled back, so it cannot
 be used in a transaction block.
 
-The :eql:synopsis:`CONFIGURE SYSTEM INSERT` variant is used for composite
+The :eql:synopsis:`CONFIGURE INSTANCE INSERT` variant is used for composite
 configuration parameters, such as ``Auth``.
 
 
@@ -66,7 +66,7 @@ Set the listen_addresses parameter:
 
 .. code-block:: edgeql
 
-    CONFIGURE SYSTEM SET listen_addresses := {'127.0.0.1', '::1'};
+    CONFIGURE INSTANCE SET listen_addresses := {'127.0.0.1', '::1'};
 
 Set the query_work_mem parameter for the duration of the session:
 
@@ -84,4 +84,4 @@ Remove all Trust authentication methods:
 
 .. code-block:: edgeql
 
-    CONFIGURE SYSTEM RESET Auth FILTER Auth.method IS Trust;
+    CONFIGURE INSTANCE RESET Auth FILTER Auth.method IS Trust;

--- a/edb/edgeql-parser/src/keywords.rs
+++ b/edb/edgeql-parser/src/keywords.rs
@@ -33,6 +33,7 @@ pub const UNRESERVED_KEYWORDS: &[&str] = &[
     "index",
     "infix",
     "inheritable",
+    "instance",
     "into",
     "isolation",
     "json",

--- a/edb/edgeql-rust/tests/normalize.rs
+++ b/edb/edgeql-rust/tests/normalize.rs
@@ -13,9 +13,9 @@ fn test_verbatim() {
 #[test]
 fn test_configure() {
     let entry = normalize(r###"
-        CONFIGURE SYSTEM SET some_setting := 7
+        CONFIGURE INSTANCE SET some_setting := 7
     "###).unwrap();
-    assert_eq!(entry.processed_source, "CONFIGURE SYSTEM SET some_setting:=7");
+    assert_eq!(entry.processed_source, "CONFIGURE INSTANCE SET some_setting:=7");
     assert_eq!(entry.variables, vec![]);
 }
 

--- a/edb/edgeql/ast.py
+++ b/edb/edgeql/ast.py
@@ -75,7 +75,7 @@ class CardinalityModifier(s_enum.StrEnum):
 class DescribeGlobal(s_enum.StrEnum):
     Schema = 'SCHEMA'
     DatabaseConfig = 'DATABASE CONFIG'
-    SystemConfig = 'SYSTEM CONFIG'
+    InstanceConfig = 'INSTANCE CONFIG'
     Roles = 'ROLES'
 
     def to_edgeql(self) -> str:

--- a/edb/edgeql/compiler/config.py
+++ b/edb/edgeql/compiler/config.py
@@ -136,7 +136,7 @@ def compile_ConfigInsert(
 
     info = _validate_op(expr, ctx=ctx)
 
-    if expr.scope is not qltypes.ConfigScope.SYSTEM:
+    if expr.scope is not qltypes.ConfigScope.INSTANCE:
         raise errors.UnsupportedFeatureError(
             f'CONFIGURE {expr.scope} INSERT is not supported'
         )
@@ -337,10 +337,10 @@ def _validate_op(
     else:
         affects_compilation = False
 
-    if system and expr.scope is not qltypes.ConfigScope.SYSTEM:
+    if system and expr.scope is not qltypes.ConfigScope.INSTANCE:
         raise errors.ConfigurationError(
             f'{name!r} is a system-level configuration parameter; '
-            f'use "CONFIGURE SYSTEM"')
+            f'use "CONFIGURE INSTANCE"')
 
     return SettingInfo(param_name=name,
                        param_type=cfg_type,

--- a/edb/edgeql/compiler/stmt.py
+++ b/edb/edgeql/compiler/stmt.py
@@ -843,7 +843,7 @@ def compile_DescribeStmt(
                 raise errors.QueryError(
                     f'cannot describe config as {ql.language}')
 
-        elif ql.object is qlast.DescribeGlobal.SystemConfig:
+        elif ql.object is qlast.DescribeGlobal.InstanceConfig:
             if ql.language is qltypes.DescribeLanguage.DDL:
                 function_call = dispatch.compile(
                     qlast.FunctionCall(

--- a/edb/edgeql/parser/grammar/config.py
+++ b/edb/edgeql/parser/grammar/config.py
@@ -35,7 +35,10 @@ class ConfigScope(Nonterm):
         self.val = qltypes.ConfigScope.DATABASE
 
     def reduce_SYSTEM(self, *kids):
-        self.val = qltypes.ConfigScope.SYSTEM
+        self.val = qltypes.ConfigScope.INSTANCE
+
+    def reduce_INSTANCE(self, *kids):
+        self.val = qltypes.ConfigScope.INSTANCE
 
 
 class ConfigOp(Nonterm):

--- a/edb/edgeql/parser/grammar/statements.py
+++ b/edb/edgeql/parser/grammar/statements.py
@@ -198,13 +198,17 @@ class DescribeStmt(Nonterm):
             options=kids[4].val.options,
         )
 
-    def reduce_DESCRIBE_SYSTEM_CONFIG(self, *kids):
-        """%reduce DESCRIBE SYSTEM CONFIG DescribeFormat"""
+    def reduce_DESCRIBE_INSTANCE_CONFIG(self, *kids):
+        """%reduce DESCRIBE INSTANCE CONFIG DescribeFormat"""
         self.val = qlast.DescribeStmt(
-            object=qlast.DescribeGlobal.SystemConfig,
+            object=qlast.DescribeGlobal.InstanceConfig,
             language=kids[3].val.language,
             options=kids[3].val.options,
         )
+
+    def reduce_DESCRIBE_SYSTEM_CONFIG(self, *kids):
+        """%reduce DESCRIBE SYSTEM CONFIG DescribeFormat"""
+        return self.reduce_DESCRIBE_INSTANCE_CONFIG(*kids)
 
     def reduce_DESCRIBE_ROLES(self, *kids):
         """%reduce DESCRIBE ROLES DescribeFormat"""

--- a/edb/edgeql/qltypes.py
+++ b/edb/edgeql/qltypes.py
@@ -228,7 +228,7 @@ class LinkTargetDeleteAction(s_enum.StrEnum):
 
 class ConfigScope(s_enum.StrEnum):
 
-    SYSTEM = 'SYSTEM'
+    INSTANCE = 'INSTANCE'
     DATABASE = 'DATABASE'
     SESSION = 'SESSION'
 

--- a/edb/lib/_testmode.edgeql
+++ b/edb/lib/_testmode.edgeql
@@ -42,7 +42,7 @@ CREATE TYPE cfg::Subclass2 EXTENDING cfg::Base {
 };
 
 
-CREATE TYPE cfg::TestSystemConfig {
+CREATE TYPE cfg::TestInstanceConfig {
     CREATE REQUIRED PROPERTY name -> std::str {
         CREATE CONSTRAINT std::exclusive;
     };
@@ -55,7 +55,7 @@ ALTER TYPE cfg::AbstractConfig {
     CREATE MULTI LINK sessobj -> cfg::TestSessionConfig {
         CREATE ANNOTATION cfg::internal := 'true';
     };
-    CREATE MULTI LINK sysobj -> cfg::TestSystemConfig {
+    CREATE MULTI LINK sysobj -> cfg::TestInstanceConfig {
         CREATE ANNOTATION cfg::internal := 'true';
     };
 

--- a/edb/lib/cfg.edgeql
+++ b/edb/lib/cfg.edgeql
@@ -111,7 +111,7 @@ CREATE ABSTRACT TYPE cfg::AbstractConfig extending cfg::ConfigObject {
 
 
 CREATE TYPE cfg::Config EXTENDING cfg::AbstractConfig;
-CREATE TYPE cfg::SystemConfig EXTENDING cfg::AbstractConfig;
+CREATE TYPE cfg::InstanceConfig EXTENDING cfg::AbstractConfig;
 CREATE TYPE cfg::DatabaseConfig EXTENDING cfg::AbstractConfig;
 
 

--- a/edb/pgsql/codegen.py
+++ b/edb/pgsql/codegen.py
@@ -740,7 +740,7 @@ class SQLSourceGenerator(codegen.SourceGenerator):
         self.write(')')
 
     def visit_AlterSystem(self, node):
-        self.write('ALTER SYSTEM ')
+        self.write('ALTER INSTANCE ')
         if node.value is not None:
             self.write('SET ')
             self.write(common.quote_ident(node.name))

--- a/edb/pgsql/compiler/config.py
+++ b/edb/pgsql/compiler/config.py
@@ -84,7 +84,7 @@ def compile_ConfigSet(
 
     result: pgast.BaseExpr
 
-    if op.scope is qltypes.ConfigScope.SYSTEM and op.backend_setting:
+    if op.scope is qltypes.ConfigScope.INSTANCE and op.backend_setting:
         assert isinstance(val, pgast.SelectStmt) and len(val.target_list) == 1
         valval = val.target_list[0].val
         if isinstance(valval, pgast.TypeCast):
@@ -127,7 +127,7 @@ def compile_ConfigSet(
             env=ctx.env,
         )
 
-    elif op.scope is qltypes.ConfigScope.SYSTEM:
+    elif op.scope is qltypes.ConfigScope.INSTANCE:
         result_row = pgast.RowExpr(
             args=[
                 pgast.StringConstant(val='SET'),
@@ -256,7 +256,7 @@ def compile_ConfigReset(
 
     stmt: pgast.BaseExpr
 
-    if op.scope is qltypes.ConfigScope.SYSTEM and op.backend_setting:
+    if op.scope is qltypes.ConfigScope.INSTANCE and op.backend_setting:
         stmt = pgast.AlterSystem(
             name=op.backend_setting,
             value=None,
@@ -293,7 +293,7 @@ def compile_ConfigReset(
             env=ctx.env,
         )
 
-    elif op.scope is qltypes.ConfigScope.SYSTEM:
+    elif op.scope is qltypes.ConfigScope.INSTANCE:
 
         if op.selector is None:
             # Scalar reset
@@ -458,7 +458,7 @@ def top_output_as_config_op(
 
     assert isinstance(ir_set.expr, irast.ConfigCommand)
 
-    if ir_set.expr.scope is qltypes.ConfigScope.SYSTEM:
+    if ir_set.expr.scope is qltypes.ConfigScope.INSTANCE:
         alias = env.aliases.get('cfg')
         subrvar = pgast.RangeSubselect(
             subquery=stmt,

--- a/edb/server/bootstrap.py
+++ b/edb/server/bootstrap.py
@@ -950,7 +950,7 @@ async def _configure(
 
     if insecure:
         scripts.append('''
-            CONFIGURE SYSTEM INSERT Auth {
+            CONFIGURE INSTANCE INSERT Auth {
                 priority := 0,
                 method := (INSERT Trust),
             };

--- a/edb/server/cluster.py
+++ b/edb/server/cluster.py
@@ -280,7 +280,7 @@ class BaseCluster:
 
     def trust_local_connections(self):
         self._admin_query('''
-            CONFIGURE SYSTEM INSERT Auth {
+            CONFIGURE INSTANCE INSERT Auth {
                 priority := 0,
                 method := (INSERT Trust),
             }

--- a/edb/server/compiler/compiler.py
+++ b/edb/server/compiler/compiler.py
@@ -1453,11 +1453,11 @@ class Compiler:
             self._assert_not_in_migration_block(ctx, ql)
 
         if (
-            ql.scope is qltypes.ConfigScope.SYSTEM
+            ql.scope is qltypes.ConfigScope.INSTANCE
             and not current_tx.is_implicit()
         ):
             raise errors.QueryError(
-                'CONFIGURE SYSTEM cannot be executed in a transaction block')
+                'CONFIGURE INSTANCE cannot be executed in a transaction block')
 
         ir = qlcompiler.compile_ast_to_ir(
             ql,
@@ -1496,7 +1496,7 @@ class Compiler:
             )
             current_tx.update_database_config(database_config)
 
-        elif ql.scope is qltypes.ConfigScope.SYSTEM:
+        elif ql.scope is qltypes.ConfigScope.INSTANCE:
             try:
                 config_op = ireval.evaluate_to_config_op(ir, schema=schema)
             except ireval.UnsupportedExpressionError:
@@ -1779,11 +1779,11 @@ class Compiler:
             elif isinstance(comp, dbstate.SessionStateQuery):
                 unit.sql += comp.sql
 
-                if comp.config_scope is qltypes.ConfigScope.SYSTEM:
+                if comp.config_scope is qltypes.ConfigScope.INSTANCE:
                     if (not ctx.state.current_tx().is_implicit() or
                             statements_len > 1):
                         raise errors.QueryError(
-                            'CONFIGURE SYSTEM cannot be executed in a '
+                            'CONFIGURE INSTANCE cannot be executed in a '
                             'transaction block')
 
                     unit.system_config = True

--- a/edb/server/compiler/dbstate.py
+++ b/edb/server/compiler/dbstate.py
@@ -246,7 +246,7 @@ class QueryUnit:
     in_type_id: bytes = sertypes.EMPTY_TUPLE_ID
     in_type_args: Optional[List[Param]] = None
 
-    # Set only when this unit contains a CONFIGURE SYSTEM command.
+    # Set only when this unit contains a CONFIGURE INSTANCE command.
     system_config: bool = False
     # Set only when this unit contains a CONFIGURE DATABASE command.
     database_config: bool = False

--- a/edb/server/compiler_pool/worker.py
+++ b/edb/server/compiler_pool/worker.py
@@ -57,7 +57,7 @@ COMPILER: compiler.Compiler
 LAST_STATE: Optional[compiler.dbstate.CompilerConnectionState] = None
 STD_SCHEMA: s_schema.FlatSchema
 GLOBAL_SCHEMA: s_schema.FlatSchema
-SYSTEM_CONFIG: immutables.Map[str, config.SettingValue]
+INSTANCE_CONFIG: immutables.Map[str, config.SettingValue]
 
 # Abort the template process if more than MAX_WORKER_SPANWS new workers are
 # created continuously - it probably means the worker cannot start correctly
@@ -76,7 +76,7 @@ def __init_worker__(
     global COMPILER
     global STD_SCHEMA
     global GLOBAL_SCHEMA
-    global SYSTEM_CONFIG
+    global INSTANCE_CONFIG
 
     (
         dbs,
@@ -96,7 +96,7 @@ def __init_worker__(
     )
     STD_SCHEMA = std_schema
     GLOBAL_SCHEMA = global_schema
-    SYSTEM_CONFIG = system_config
+    INSTANCE_CONFIG = system_config
 
     COMPILER.initialize(
         std_schema, refl_schema, schema_class_layout,
@@ -113,7 +113,7 @@ def __sync__(
 ) -> state.DatabaseState:
     global DBS
     global GLOBAL_SCHEMA
-    global SYSTEM_CONFIG
+    global INSTANCE_CONFIG
 
     try:
         db = DBS.get(dbname)
@@ -149,7 +149,7 @@ def __sync__(
             GLOBAL_SCHEMA = pickle.loads(global_schema)
 
         if system_config is not None:
-            SYSTEM_CONFIG = pickle.loads(system_config)
+            INSTANCE_CONFIG = pickle.loads(system_config)
 
     except Exception as ex:
         raise state.FailedStateSync(
@@ -182,7 +182,7 @@ def compile(
         GLOBAL_SCHEMA,
         db.reflection_cache,
         db.database_config,
-        SYSTEM_CONFIG,
+        INSTANCE_CONFIG,
         *compile_args,
         **compile_kwargs
     )
@@ -231,7 +231,7 @@ def compile_notebook(
         GLOBAL_SCHEMA,
         db.reflection_cache,
         db.database_config,
-        SYSTEM_CONFIG,
+        INSTANCE_CONFIG,
         *compile_args,
         **compile_kwargs
     )
@@ -267,7 +267,7 @@ def compile_graphql(
         db.user_schema,
         GLOBAL_SCHEMA,
         db.database_config,
-        SYSTEM_CONFIG,
+        INSTANCE_CONFIG,
         *compile_args,
         **compile_kwargs
     )

--- a/edb/server/config/ops.py
+++ b/edb/server/config/ops.py
@@ -192,7 +192,7 @@ class Operation(NamedTuple):
         value: Any,
     ) -> SettingsMap:
 
-        if self.scope is qltypes.ConfigScope.SYSTEM:
+        if self.scope is qltypes.ConfigScope.INSTANCE:
             source = 'system override'
         elif self.scope is qltypes.ConfigScope.DATABASE:
             source = 'database'

--- a/edb/server/dbview/dbview.pxd
+++ b/edb/server/dbview/dbview.pxd
@@ -21,7 +21,7 @@ cpdef enum SideEffects:
 
     SchemaChanges = 1 << 0
     DatabaseConfigChanges = 1 << 1
-    SystemConfigChanges = 1 << 2
+    InstanceConfigChanges = 1 << 2
     RoleChanges = 1 << 3
     GlobalSchemaChanges = 1 << 4
 

--- a/edb/server/dbview/dbview.pyx
+++ b/edb/server/dbview/dbview.pyx
@@ -443,7 +443,7 @@ cdef class DatabaseConnectionView:
                 )
                 side_effects |= SideEffects.SchemaChanges
             if query_unit.system_config:
-                side_effects |= SideEffects.SystemConfigChanges
+                side_effects |= SideEffects.InstanceConfigChanges
             if query_unit.database_config:
                 side_effects |= SideEffects.DatabaseConfigChanges
             if query_unit.global_schema is not None:
@@ -481,7 +481,7 @@ cdef class DatabaseConnectionView:
                 )
                 side_effects |= SideEffects.SchemaChanges
             if self._in_tx_with_sysconfig:
-                side_effects |= SideEffects.SystemConfigChanges
+                side_effects |= SideEffects.InstanceConfigChanges
             if self._in_tx_with_dbconfig:
                 side_effects |= SideEffects.DatabaseConfigChanges
             if query_unit.global_schema is not None:
@@ -511,7 +511,7 @@ cdef class DatabaseConnectionView:
             if setting.backend_setting:
                 continue
 
-            if op.scope is config.ConfigScope.SYSTEM:
+            if op.scope is config.ConfigScope.INSTANCE:
                 await self._db._index.apply_system_config_op(conn, op)
             elif op.scope is config.ConfigScope.DATABASE:
                 self.set_database_config(

--- a/edb/server/defines.py
+++ b/edb/server/defines.py
@@ -34,7 +34,7 @@ EDGEDB_VISIBLE_METADATA_PREFIX = r'EdgeDB metadata follows, do not modify.\n'
 EDGEDB_SPECIAL_DBS = {EDGEDB_TEMPLATE_DB, EDGEDB_SYSTEM_DB}
 
 # Increment this whenever the database layout or stdlib changes.
-EDGEDB_CATALOG_VERSION = 2021_07_19_00_00
+EDGEDB_CATALOG_VERSION = 2021_07_20_00_00
 
 # Resource limit on open FDs for the server process.
 # By default, at least on macOS, the max number of open FDs

--- a/edb/server/protocol/binary.pyx
+++ b/edb/server/protocol/binary.pyx
@@ -1120,7 +1120,7 @@ cdef class EdgeConnection:
                     dbname=self.get_dbview().dbname,
                 ),
             )
-        if side_effects & dbview.SideEffects.SystemConfigChanges:
+        if side_effects & dbview.SideEffects.InstanceConfigChanges:
             self.server.create_task(
                 self.server._signal_sysevent(
                     'system-config-changes',
@@ -2480,9 +2480,9 @@ cdef class EdgeConnection:
                 try:
                     if query_unit.config_ops:
                         for op in query_unit.config_ops:
-                            if op.scope is config.ConfigScope.SYSTEM:
+                            if op.scope is config.ConfigScope.INSTANCE:
                                 raise errors.ProtocolError(
-                                    'CONFIGURE SYSTEM cannot be executed'
+                                    'CONFIGURE INSTANCE cannot be executed'
                                     ' in dump restore'
                                 )
 

--- a/edb/server/server.py
+++ b/edb/server/server.py
@@ -655,15 +655,15 @@ class Server:
         self._dbindex.unregister_db(dbname)
 
     async def _on_system_config_add(self, setting_name, value):
-        # CONFIGURE SYSTEM INSERT ConfigObject;
+        # CONFIGURE INSTANCE INSERT ConfigObject;
         pass
 
     async def _on_system_config_rem(self, setting_name, value):
-        # CONFIGURE SYSTEM RESET ConfigObject;
+        # CONFIGURE INSTANCE RESET ConfigObject;
         pass
 
     async def _on_system_config_set(self, setting_name, value):
-        # CONFIGURE SYSTEM SET setting_name := value;
+        # CONFIGURE INSTANCE SET setting_name := value;
         if setting_name == 'listen_addresses':
             await self._restart_servers_new_addr(value, self._listen_port)
 
@@ -671,7 +671,7 @@ class Server:
             await self._restart_servers_new_addr(self._listen_host, value)
 
     async def _on_system_config_reset(self, setting_name):
-        # CONFIGURE SYSTEM RESET setting_name;
+        # CONFIGURE INSTANCE RESET setting_name;
         if setting_name == 'listen_addresses':
             await self._restart_servers_new_addr(
                 'localhost', self._listen_port)
@@ -681,21 +681,21 @@ class Server:
                 self._listen_host, defines.EDGEDB_PORT)
 
     async def _after_system_config_add(self, setting_name, value):
-        # CONFIGURE SYSTEM INSERT ConfigObject;
+        # CONFIGURE INSTANCE INSERT ConfigObject;
         if setting_name == 'auth':
             self._populate_sys_auth()
 
     async def _after_system_config_rem(self, setting_name, value):
-        # CONFIGURE SYSTEM RESET ConfigObject;
+        # CONFIGURE INSTANCE RESET ConfigObject;
         if setting_name == 'auth':
             self._populate_sys_auth()
 
     async def _after_system_config_set(self, setting_name, value):
-        # CONFIGURE SYSTEM SET setting_name := value;
+        # CONFIGURE INSTANCE SET setting_name := value;
         pass
 
     async def _after_system_config_reset(self, setting_name):
-        # CONFIGURE SYSTEM RESET setting_name;
+        # CONFIGURE INSTANCE RESET setting_name;
         pass
 
     async def _acquire_sys_pgcon(self):

--- a/tests/test_edgeql_data_migration.py
+++ b/tests/test_edgeql_data_migration.py
@@ -9034,12 +9034,12 @@ class TestEdgeQLDataMigration(tb.DDLTestCase):
 
         async with self.assertRaisesRegexTx(
             edgedb.QueryError,
-            r"cannot execute CONFIGURE SYSTEM"
+            r"cannot execute CONFIGURE INSTANCE"
             r" in a migration block",
         ):
             await self.start_migration('type Foo;')
             await self.con.execute('''
-                CONFIGURE SYSTEM SET _foo := 123;
+                CONFIGURE INSTANCE SET _foo := 123;
             ''')
 
         async with self.assertRaisesRegexTx(

--- a/tests/test_edgeql_syntax.py
+++ b/tests/test_edgeql_syntax.py
@@ -5053,25 +5053,25 @@ aa';
 
     def test_edgeql_syntax_configure_01(self):
         """
-        CONFIGURE SYSTEM SET foo := (SELECT User);
+        CONFIGURE INSTANCE SET foo := (SELECT User);
         CONFIGURE SESSION SET foo := (SELECT User);
         CONFIGURE CURRENT DATABASE SET foo := (SELECT User);
-        CONFIGURE SYSTEM SET cfg::foo := (SELECT User);
+        CONFIGURE INSTANCE SET cfg::foo := (SELECT User);
         CONFIGURE SESSION SET cfg::foo := (SELECT User);
         CONFIGURE CURRENT DATABASE SET cfg::foo := (SELECT User);
-        CONFIGURE SYSTEM RESET foo;
+        CONFIGURE INSTANCE RESET foo;
         CONFIGURE SESSION RESET foo;
         CONFIGURE CURRENT DATABASE RESET foo;
-        CONFIGURE SYSTEM RESET cfg::foo;
+        CONFIGURE INSTANCE RESET cfg::foo;
         CONFIGURE SESSION RESET cfg::foo;
         CONFIGURE CURRENT DATABASE RESET cfg::foo;
-        CONFIGURE SYSTEM INSERT Foo {bar := (SELECT 1)};
+        CONFIGURE INSTANCE INSERT Foo {bar := (SELECT 1)};
         CONFIGURE SESSION INSERT Foo {bar := (SELECT 1)};
         CONFIGURE CURRENT DATABASE INSERT Foo {bar := (SELECT 1)};
-        CONFIGURE SYSTEM INSERT cfg::Foo {bar := (SELECT 1)};
+        CONFIGURE INSTANCE INSERT cfg::Foo {bar := (SELECT 1)};
         CONFIGURE SESSION INSERT cfg::Foo {bar := (SELECT 1)};
         CONFIGURE CURRENT DATABASE INSERT cfg::Foo {bar := (SELECT 1)};
-        CONFIGURE SYSTEM RESET Foo FILTER (.bar = 2);
+        CONFIGURE INSTANCE RESET Foo FILTER (.bar = 2);
         CONFIGURE SESSION RESET Foo FILTER (.bar = 2);
         CONFIGURE CURRENT DATABASE RESET Foo FILTER (.bar = 2);
         """
@@ -5354,14 +5354,14 @@ aa';
 
     def test_edgeql_syntax_describe_05(self):
         """
-        DESCRIBE SYSTEM CONFIG;
+        DESCRIBE INSTANCE CONFIG;
 % OK %
-        DESCRIBE SYSTEM CONFIG AS DDL;
+        DESCRIBE INSTANCE CONFIG AS DDL;
         """
 
     def test_edgeql_syntax_describe_06(self):
         """
-        DESCRIBE SYSTEM CONFIG AS DDL;
+        DESCRIBE INSTANCE CONFIG AS DDL;
         """
 
     def test_edgeql_syntax_describe_07(self):
@@ -5374,4 +5374,11 @@ aa';
     def test_edgeql_syntax_describe_08(self):
         """
         DESCRIBE ROLES AS DDL;
+        """
+
+    def test_edgeql_syntax_describe_09(self):
+        """
+        DESCRIBE SYSTEM CONFIG;
+% OK %
+        DESCRIBE INSTANCE CONFIG AS DDL;
         """

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -51,7 +51,7 @@ class TestServerAuth(tb.ConnectedTestCase):
         await conn.aclose()
 
         await self.con.query('''
-            CONFIGURE SYSTEM INSERT Auth {
+            CONFIGURE INSTANCE INSERT Auth {
                 comment := 'test',
                 priority := 0,
                 method := (INSERT Trust),
@@ -68,7 +68,7 @@ class TestServerAuth(tb.ConnectedTestCase):
 
             # insert password auth with a higher priority
             await self.con.query('''
-                CONFIGURE SYSTEM INSERT Auth {
+                CONFIGURE INSTANCE INSERT Auth {
                     comment := 'test-2',
                     priority := -1,
                     method := (INSERT SCRAM),
@@ -87,11 +87,11 @@ class TestServerAuth(tb.ConnectedTestCase):
 
         finally:
             await self.con.query('''
-                CONFIGURE SYSTEM RESET Auth FILTER .comment = 'test'
+                CONFIGURE INSTANCE RESET Auth FILTER .comment = 'test'
             ''')
 
             await self.con.query('''
-                CONFIGURE SYSTEM RESET Auth FILTER .comment = 'test-2'
+                CONFIGURE INSTANCE RESET Auth FILTER .comment = 'test-2'
             ''')
 
             await self.con.query('''

--- a/tests/test_server_config.py
+++ b/tests/test_server_config.py
@@ -116,7 +116,7 @@ class TestServerConfigUtils(unittest.TestCase):
                 name=s.name,
                 value=s.default,
                 source='system override',
-                scope=qltypes.ConfigScope.SYSTEM,
+                scope=qltypes.ConfigScope.INSTANCE,
             ) for s in testspec1.values()
         })
 
@@ -128,49 +128,49 @@ class TestServerConfigUtils(unittest.TestCase):
                     'name': 'bool',
                     'value': True,
                     'source': 'system override',
-                    'scope': qltypes.ConfigScope.SYSTEM,
+                    'scope': qltypes.ConfigScope.INSTANCE,
                 },
                 'bools': {
                     'name': 'bools',
                     'value': [],
                     'source': 'system override',
-                    'scope': qltypes.ConfigScope.SYSTEM,
+                    'scope': qltypes.ConfigScope.INSTANCE,
                 },
                 'int': {
                     'name': 'int',
                     'value': 0,
                     'source': 'system override',
-                    'scope': qltypes.ConfigScope.SYSTEM,
+                    'scope': qltypes.ConfigScope.INSTANCE,
                 },
                 'ints': {
                     'name': 'ints',
                     'value': [],
                     'source': 'system override',
-                    'scope': qltypes.ConfigScope.SYSTEM,
+                    'scope': qltypes.ConfigScope.INSTANCE,
                 },
                 'port': {
                     'name': 'port',
                     'value': testspec1['port'].default.to_json_value(),
                     'source': 'system override',
-                    'scope': qltypes.ConfigScope.SYSTEM,
+                    'scope': qltypes.ConfigScope.INSTANCE,
                 },
                 'ports': {
                     'name': 'ports',
                     'value': [],
                     'source': 'system override',
-                    'scope': qltypes.ConfigScope.SYSTEM,
+                    'scope': qltypes.ConfigScope.INSTANCE,
                 },
                 'str': {
                     'name': 'str',
                     'value': 'hello',
                     'source': 'system override',
-                    'scope': qltypes.ConfigScope.SYSTEM,
+                    'scope': qltypes.ConfigScope.INSTANCE,
                 },
                 'strings': {
                     'name': 'strings',
                     'value': [],
                     'source': 'system override',
-                    'scope': qltypes.ConfigScope.SYSTEM,
+                    'scope': qltypes.ConfigScope.INSTANCE,
                 },
             }
         )
@@ -182,7 +182,7 @@ class TestServerConfigUtils(unittest.TestCase):
 
         op = ops.Operation(
             ops.OpCode.CONFIG_ADD,
-            config.ConfigScope.SYSTEM,
+            config.ConfigScope.INSTANCE,
             'ports',
             make_port_value(database='f1')
         )
@@ -190,7 +190,7 @@ class TestServerConfigUtils(unittest.TestCase):
 
         op = ops.Operation(
             ops.OpCode.CONFIG_ADD,
-            config.ConfigScope.SYSTEM,
+            config.ConfigScope.INSTANCE,
             'ports',
             make_port_value(database='f2')
         )
@@ -209,7 +209,7 @@ class TestServerConfigUtils(unittest.TestCase):
 
         op = ops.Operation(
             ops.OpCode.CONFIG_REM,
-            config.ConfigScope.SYSTEM,
+            config.ConfigScope.INSTANCE,
             'ports',
             make_port_value(database='f1')
         )
@@ -223,7 +223,7 @@ class TestServerConfigUtils(unittest.TestCase):
 
         op = ops.Operation(
             ops.OpCode.CONFIG_REM,
-            config.ConfigScope.SYSTEM,
+            config.ConfigScope.INSTANCE,
             'ports',
             make_port_value(database='f1')
         )
@@ -235,7 +235,7 @@ class TestServerConfigUtils(unittest.TestCase):
 
         op = ops.Operation(
             ops.OpCode.CONFIG_ADD,
-            config.ConfigScope.SYSTEM,
+            config.ConfigScope.INSTANCE,
             'ports',
             make_port_value(zzzzzzz='zzzzz')
         )
@@ -245,7 +245,7 @@ class TestServerConfigUtils(unittest.TestCase):
 
         op = ops.Operation(
             ops.OpCode.CONFIG_ADD,
-            config.ConfigScope.SYSTEM,
+            config.ConfigScope.INSTANCE,
             'ports',
             make_port_value(concurrency='a')
         )
@@ -255,7 +255,7 @@ class TestServerConfigUtils(unittest.TestCase):
 
         op = ops.Operation(
             ops.OpCode.CONFIG_ADD,
-            config.ConfigScope.SYSTEM,
+            config.ConfigScope.INSTANCE,
             'por',
             make_port_value(concurrency='a')
         )
@@ -265,7 +265,7 @@ class TestServerConfigUtils(unittest.TestCase):
 
         op = ops.Operation(
             ops.OpCode.CONFIG_ADD,
-            config.ConfigScope.SYSTEM,
+            config.ConfigScope.INSTANCE,
             'ports',
             make_port_value(address=["aaa", 123])
         )
@@ -275,7 +275,7 @@ class TestServerConfigUtils(unittest.TestCase):
 
         op = ops.Operation(
             ops.OpCode.CONFIG_ADD,
-            config.ConfigScope.SYSTEM,
+            config.ConfigScope.INSTANCE,
             'ports',
             make_port_value(address="aaa")
         )
@@ -378,14 +378,14 @@ class TestServerConfig(tb.QueryTestCase):
                 'cannot be executed in a transaction block'):
             await self.con.execute('''
                 CONFIGURE SESSION SET __internal_no_const_folding := false;
-                CONFIGURE SYSTEM SET __internal_testvalue := 1;
+                CONFIGURE INSTANCE SET __internal_testvalue := 1;
             ''')
 
         with self.assertRaisesRegex(
                 edgedb.QueryError,
                 'cannot be executed in a transaction block'):
             await self.con.execute('''
-                CONFIGURE SYSTEM SET __internal_testvalue := 1;
+                CONFIGURE INSTANCE SET __internal_testvalue := 1;
                 CONFIGURE SESSION SET __internal_no_const_folding := false;
             ''')
 
@@ -394,7 +394,7 @@ class TestServerConfig(tb.QueryTestCase):
                 'cannot be executed in a transaction block'):
             async with self.con.transaction():
                 await self.con.query('''
-                    CONFIGURE SYSTEM SET __internal_testvalue := 1;
+                    CONFIGURE INSTANCE SET __internal_testvalue := 1;
                 ''')
 
         with self.assertRaisesRegex(
@@ -416,7 +416,9 @@ class TestServerConfig(tb.QueryTestCase):
                 edgedb.QueryError,
                 'module must be either \'cfg\' or empty'):
             await self.con.query('''
-                CONFIGURE SYSTEM INSERT cf::TestSystemConfig { name := 'foo' };
+                CONFIGURE INSTANCE INSERT cf::TestInstanceConfig {
+                    name := 'foo'
+                };
             ''')
 
     async def test_server_proto_configure_02(self):
@@ -444,7 +446,7 @@ class TestServerConfig(tb.QueryTestCase):
             # to test that we handle keywords in a case-insensitive manner
             # in constant extraction code.
             await self.con.query('''
-                Configure SYSTEM SET __internal_testvalue := 1;
+                Configure INSTANCE SET __internal_testvalue := 1;
             ''')
 
             conf = await self.con.query_one('''
@@ -467,7 +469,7 @@ class TestServerConfig(tb.QueryTestCase):
             self.assertEqual(conf['source'], 'session')
         finally:
             await self.con.execute('''
-                CONFIGURE SYSTEM RESET __internal_testvalue
+                CONFIGURE INSTANCE RESET __internal_testvalue
             ''')
             await self.con.execute('''
                 CONFIGURE SESSION RESET multiprop
@@ -482,18 +484,18 @@ class TestServerConfig(tb.QueryTestCase):
         )
 
         await self.con.query('''
-            CONFIGURE SYSTEM INSERT TestSystemConfig { name := 'test_03' };
+            CONFIGURE INSTANCE INSERT TestInstanceConfig { name := 'test_03' };
         ''')
 
         await self.con.query('''
-            CONFIGURE SYSTEM INSERT cfg::TestSystemConfig {
+            CONFIGURE INSTANCE INSERT cfg::TestInstanceConfig {
                 name := 'test_03_01'
             };
         ''')
 
         with self.assertRaisesRegex(edgedb.InterfaceError, r'\bquery_one\('):
             await self.con.query_one('''
-                CONFIGURE SYSTEM INSERT cfg::TestSystemConfig {
+                CONFIGURE INSTANCE INSERT cfg::TestInstanceConfig {
                     name := 'test_03_0122222222'
                 };
             ''')
@@ -515,8 +517,8 @@ class TestServerConfig(tb.QueryTestCase):
         )
 
         await self.con.query('''
-            CONFIGURE SYSTEM
-            RESET TestSystemConfig FILTER .name = 'test_03';
+            CONFIGURE INSTANCE
+            RESET TestInstanceConfig FILTER .name = 'test_03';
         ''')
 
         await self.assert_query_result(
@@ -532,8 +534,8 @@ class TestServerConfig(tb.QueryTestCase):
         )
 
         await self.con.query('''
-            CONFIGURE SYSTEM
-            RESET TestSystemConfig FILTER .name = 'test_03_01';
+            CONFIGURE INSTANCE
+            RESET TestInstanceConfig FILTER .name = 'test_03_01';
         ''')
 
         await self.assert_query_result(
@@ -546,12 +548,12 @@ class TestServerConfig(tb.QueryTestCase):
 
         # Repeat reset that doesn't match anything this time.
         await self.con.query('''
-            CONFIGURE SYSTEM
-            RESET TestSystemConfig FILTER .name = 'test_03_01';
+            CONFIGURE INSTANCE
+            RESET TestInstanceConfig FILTER .name = 'test_03_01';
         ''')
 
         await self.con.query('''
-            CONFIGURE SYSTEM INSERT TestSystemConfig {
+            CONFIGURE INSTANCE INSERT TestInstanceConfig {
                 name := 'test_03',
                 obj := (INSERT Subclass1 { name := 'foo', sub1 := 'sub1' })
             }
@@ -580,7 +582,7 @@ class TestServerConfig(tb.QueryTestCase):
         )
 
         await self.con.query('''
-            CONFIGURE SYSTEM INSERT TestSystemConfig {
+            CONFIGURE INSTANCE INSERT TestInstanceConfig {
                 name := 'test_03_01',
                 obj := (INSERT Subclass2 { name := 'bar', sub2 := 'sub2' })
             }
@@ -617,7 +619,7 @@ class TestServerConfig(tb.QueryTestCase):
         )
 
         await self.con.query('''
-            CONFIGURE SYSTEM RESET TestSystemConfig
+            CONFIGURE INSTANCE RESET TestInstanceConfig
             FILTER .obj.name IN {'foo', 'bar'} AND .name ILIKE 'test_03%';
         ''')
 
@@ -630,8 +632,8 @@ class TestServerConfig(tb.QueryTestCase):
         )
 
         await self.con.query('''
-            CONFIGURE SYSTEM INSERT TestSystemConfig {
-                name := 'test_03_' ++ <str>count(DETACHED TestSystemConfig),
+            CONFIGURE INSTANCE INSERT TestInstanceConfig {
+                name := 'test_03_' ++ <str>count(DETACHED TestInstanceConfig),
             }
         ''')
 
@@ -651,7 +653,7 @@ class TestServerConfig(tb.QueryTestCase):
         )
 
         await self.con.query('''
-            CONFIGURE SYSTEM RESET TestSystemConfig
+            CONFIGURE INSTANCE RESET TestInstanceConfig
             FILTER .name ILIKE 'test_03%';
         ''')
 
@@ -675,14 +677,14 @@ class TestServerConfig(tb.QueryTestCase):
                 edgedb.ConfigurationError,
                 "unrecognized configuration object 'Unrecognized'"):
             await self.con.query('''
-                CONFIGURE SYSTEM INSERT Unrecognized {name := 'test_04'}
+                CONFIGURE INSTANCE INSERT Unrecognized {name := 'test_04'}
             ''')
 
         with self.assertRaisesRegex(
                 edgedb.QueryError,
                 "must not have a FILTER clause"):
             await self.con.query('''
-                CONFIGURE SYSTEM RESET __internal_testvalue FILTER 1 = 1;
+                CONFIGURE INSTANCE RESET __internal_testvalue FILTER 1 = 1;
             ''')
 
         with self.assertRaisesRegex(
@@ -696,22 +698,22 @@ class TestServerConfig(tb.QueryTestCase):
                 edgedb.ConfigurationError,
                 "'Subclass1' cannot be configured directly"):
             await self.con.query('''
-                CONFIGURE SYSTEM INSERT Subclass1 {
+                CONFIGURE INSTANCE INSERT Subclass1 {
                     name := 'foo'
                 };
             ''')
 
         await self.con.query('''
-            CONFIGURE SYSTEM INSERT TestSystemConfig {
+            CONFIGURE INSTANCE INSERT TestInstanceConfig {
                 name := 'test_04',
             }
         ''')
 
         with self.assertRaisesRegex(
                 edgedb.ConstraintViolationError,
-                "TestSystemConfig.name violates exclusivity constraint"):
+                "TestInstanceConfig.name violates exclusivity constraint"):
             await self.con.query('''
-                CONFIGURE SYSTEM INSERT TestSystemConfig {
+                CONFIGURE INSTANCE INSERT TestInstanceConfig {
                     name := 'test_04',
                 }
             ''')
@@ -735,7 +737,7 @@ class TestServerConfig(tb.QueryTestCase):
         ''')
 
         await self.con.execute('''
-            CONFIGURE SYSTEM SET __internal_sess_testvalue := 2;
+            CONFIGURE INSTANCE SET __internal_sess_testvalue := 2;
         ''')
 
         await self.assert_query_result(
@@ -749,7 +751,7 @@ class TestServerConfig(tb.QueryTestCase):
 
         await self.assert_query_result(
             '''
-            SELECT cfg::SystemConfig.__internal_sess_testvalue
+            SELECT cfg::InstanceConfig.__internal_sess_testvalue
             ''',
             [
                 2
@@ -811,7 +813,7 @@ class TestServerConfig(tb.QueryTestCase):
             )
 
             await self.con.execute('''
-                CONFIGURE SYSTEM SET multiprop := {'4', '5'};
+                CONFIGURE INSTANCE SET multiprop := {'4', '5'};
             ''')
 
             await self.assert_query_result(
@@ -841,7 +843,7 @@ class TestServerConfig(tb.QueryTestCase):
             ''')
 
             await self.con.execute('''
-                CONFIGURE SYSTEM RESET multiprop;
+                CONFIGURE INSTANCE RESET multiprop;
             ''')
 
     async def test_server_proto_configure_07(self):
@@ -858,7 +860,7 @@ class TestServerConfig(tb.QueryTestCase):
             )
 
             await self.con.execute('''
-                CONFIGURE SYSTEM SET multiprop := {'4'};
+                CONFIGURE INSTANCE SET multiprop := {'4'};
             ''')
 
             await self.assert_query_result(
@@ -900,16 +902,16 @@ class TestServerConfig(tb.QueryTestCase):
             ''')
 
             await self.con.execute('''
-                CONFIGURE SYSTEM RESET multiprop;
+                CONFIGURE INSTANCE RESET multiprop;
             ''')
 
     async def test_server_proto_configure_describe_system_config(self):
         try:
-            conf1 = "CONFIGURE SYSTEM SET singleprop := '1337';"
+            conf1 = "CONFIGURE INSTANCE SET singleprop := '1337';"
             await self.con.execute(conf1)
 
             conf2 = textwrap.dedent('''\
-                CONFIGURE SYSTEM INSERT cfg::TestSystemConfig {
+                CONFIGURE INSTANCE INSERT cfg::TestInstanceConfig {
                     name := 'test_describe',
                     obj := (
                         (INSERT cfg::Subclass1 {
@@ -924,18 +926,18 @@ class TestServerConfig(tb.QueryTestCase):
             conf3 = "CONFIGURE SESSION SET singleprop := '42';"
             await self.con.execute(conf3)
 
-            res = await self.con.query_one('DESCRIBE SYSTEM CONFIG;')
+            res = await self.con.query_one('DESCRIBE INSTANCE CONFIG;')
             self.assertIn(conf1, res)
             self.assertIn(conf2, res)
             self.assertNotIn(conf3, res)
 
         finally:
             await self.con.execute('''
-                CONFIGURE SYSTEM
-                RESET TestSystemConfig FILTER .name = 'test_describe'
+                CONFIGURE INSTANCE
+                RESET TestInstanceConfig FILTER .name = 'test_describe'
             ''')
             await self.con.execute('''
-                CONFIGURE SYSTEM RESET singleprop;
+                CONFIGURE INSTANCE RESET singleprop;
             ''')
 
     async def test_server_proto_configure_describe_database_config(self):

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -211,7 +211,7 @@ class TestServerOps(tb.TestCase):
             con = await sd.connect()
             try:
                 max_connections = await con.query_one(
-                    'SELECT cfg::SystemConfig.__pg_max_connections LIMIT 1'
+                    'SELECT cfg::InstanceConfig.__pg_max_connections LIMIT 1'
                 )  # TODO: remove LIMIT 1 after #2402
                 self.assertEqual(int(max_connections), actual)
             finally:
@@ -231,7 +231,10 @@ class TestServerOps(tb.TestCase):
                 con = await sd.connect()
                 try:
                     max_connections = await con.query_one(
-                        'SELECT cfg::SystemConfig.__pg_max_connections LIMIT 1'
+                        '''
+                        SELECT cfg::InstanceConfig.__pg_max_connections
+                        LIMIT 1
+                        '''
                     )  # TODO: remove LIMIT 1 after #2402
                     self.assertEqual(int(max_connections), actual)
                 finally:

--- a/tests/test_server_proto.py
+++ b/tests/test_server_proto.py
@@ -2946,6 +2946,6 @@ class TestServerCapabilities(tb.QueryTestCase):
         caps = ALL_CAPABILITIES & ~enums.Capability.PERSISTENT_CONFIG
         with self.assertRaises(edgedb.ProtocolError):
             await self.con._fetchall(
-                'CONFIGURE SYSTEM SET singleprop := "42"',
+                'CONFIGURE INSTANCE SET singleprop := "42"',
                 __allow_capabilities__=caps,
             )


### PR DESCRIPTION
CONFIGURE SYSTEM proved to be confusing because we have no concept of
"system" anywhere but in EdgeQL, currently. We do have a concept of
"instances" in our tooling, so we're replacing SYSTEM with INSTANCE to
make things consistent.

The old CONFIGURE SYSTEM command is kept working, although we will start
issuing deprecation warnings for it soon.